### PR TITLE
fix: npm interprets arguments

### DIFF
--- a/lib/presets/custom/angular/deliver/prebuild.js
+++ b/lib/presets/custom/angular/deliver/prebuild.js
@@ -7,7 +7,10 @@ const packageManager = await getPackageManager();
  */
 async function prebuild() {
   try {
-    await exec(`${packageManager} run build --output-path=.edge/statics`, 'Angular', true);
+    // This is because npm interprets arguments passed directly after the script as options for npm itself, not the script itself.
+    const npmArgsForward = packageManager === 'npm' ? '--' : '';
+    // support npm, yarn, pnpm
+    await exec(`${packageManager} run build ${npmArgsForward} --output-path=.edge/statics`, 'Angular', true);
   } catch (error) {
     feedback.prebuild.error(error);
   }

--- a/lib/presets/custom/vue/deliver/prebuild.js
+++ b/lib/presets/custom/vue/deliver/prebuild.js
@@ -7,7 +7,10 @@ const packageManager = await getPackageManager();
  */
 async function prebuild() {
   try {
-    await exec(`${packageManager} run build --dest .edge/statics`, 'Vue', true);
+    // This is because npm interprets arguments passed directly after the script as options for npm itself, not the script itself.
+    const npmArgsForward = packageManager === 'npm' ? '--' : '';
+    // support npm, yarn, pnpm
+    await exec(`${packageManager} run build ${npmArgsForward} --dest .edge/statics`, 'Vue', true);
   } catch (error) {
     feedback.prebuild.error(error);
   }


### PR DESCRIPTION
Fix in Angular preset prebuild, package manager compatibility.

This is because npm interprets arguments passed directly after the script as options for npm itself, not the script itself.
I performed tests with yarn, npm and pnpm managers.

