### PR TITLE
chore: remove dev dependency

### DIFF
--- a/examples/angular-static/package.json
+++ b/examples/angular-static/package.json
@@ -27,7 +27,6 @@
     "@angular/cli": "~16.1.3",
     "@angular/compiler-cli": "^16.1.0",
     "@types/jasmine": "~4.3.0",
-    "edge-functions": "^0.0.1",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",


### PR DESCRIPTION
Removing a dev dependency that was accidentally added in the angular static example.