### PR TITLE
[ISSUE-62] Windows Compatibility

### DIFF
--- a/.github/workflows/minor.yml
+++ b/.github/workflows/minor.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-
 jobs:
   publish-release:
     strategy:

--- a/examples/angular-static/package.json
+++ b/examples/angular-static/package.json
@@ -27,7 +27,6 @@
     "@angular/cli": "~16.1.3",
     "@angular/compiler-cli": "^16.1.0",
     "@types/jasmine": "~4.3.0",
-    "edge-functions": "^0.0.1",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/lib/build/bundlers/webpack/webpack.config.js
+++ b/lib/build/bundlers/webpack/webpack.config.js
@@ -2,9 +2,11 @@ import webpack from 'webpack';
 import { join } from 'path';
 import { writeFile, mkdir } from 'fs/promises';
 import { generateTimestamp } from '#utils';
+import { fileURLToPath } from 'url';
 
 const projectRoot = process.cwd();
-const outputPath = join(projectRoot, '.edge');
+const isWindows = process.platform === 'win32';
+const outputPath = isWindows ? fileURLToPath(new URL(`file:///${join(projectRoot, '.edge')}`)) : join(projectRoot, '.edge');
 
 /**
  * Generates a build ID and saves it in the .env file (for deploy).

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -1,12 +1,13 @@
-import { join, resolve } from 'path';
+import { join, resolve, sep } from 'path';
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { writeFile, rm } from 'fs/promises';
 import { Webpack } from '#bundlers';
-import { feedback, generateTimestamp, getAbsoluteLibDirPath } from '#utils';
+import { feedback, generateTimestamp, getAbsoluteLibDirPath, debug } from '#utils';
 import { Messages } from '#constants';
 
 const vulcanLibPath = getAbsoluteLibDirPath();
 const vulcanRootPath = resolve(vulcanLibPath, '..');
+const isWindows = process.platform === 'win32';
 
 /**
  * Get the valid build presets based on the folders inside the presets/default
@@ -34,15 +35,23 @@ function getValidPresets() {
  * @param {string} alias - The desired alias.
  * @returns {string} The path corresponding to the alias.
  */
+/**
+ * Get the path corresponding to a specific alias defined in the package.json.
+ * @param {string} alias - The desired alias.
+ * @returns {string} The path corresponding to the alias.
+ */
 async function getAliasPath(alias) {
   const packageJsonPath = join(vulcanRootPath, 'package.json');
   const packageJsonContent = readFileSync(packageJsonPath, 'utf8');
   const packageJson = JSON.parse(packageJsonContent);
   let aliasPath = packageJson.imports[`#${alias}`];
   aliasPath = aliasPath.replace('./', `${vulcanRootPath}/`);
+  if (isWindows) {
+    aliasPath = aliasPath.replace(/[\\/]/g, '\\\\');  
+  }
+
   return aliasPath;
 }
-
 /**
  * Move requires and imports to file init
  * @param {string} entryContent - The file content to be fixed.
@@ -64,7 +73,6 @@ function fixImportsAndRequestsPlace(entryContent) {
 
   return newCode;
 }
-
 /**
  * Get a build context based on arguments
  * @param {string} preset - The build preset.
@@ -104,6 +112,10 @@ async function loadBuildContext(preset, entry, mode) {
     handlerFilePath = join(modePath, 'handler.js');
   }
 
+  // Convert file paths to file URLs
+  configFilePath = new URL(`file://${configFilePath}`).href;
+  prebuildFilePath = new URL(`file://${prebuildFilePath}`).href;
+  
   const config = (await import(configFilePath)).default;
   const prebuild = (await import(prebuildFilePath)).default;
   const handlerTemplate = readFileSync(handlerFilePath, 'utf-8');
@@ -139,6 +151,7 @@ async function loadBuildContext(preset, entry, mode) {
 
   return buildContext;
 }
+
 
 /**
  * Class representing a Dispatcher for build operations.

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -1,8 +1,8 @@
-import { join, resolve, sep } from 'path';
+import { join, resolve } from 'path';
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { writeFile, rm } from 'fs/promises';
 import { Webpack } from '#bundlers';
-import { feedback, generateTimestamp, getAbsoluteLibDirPath, debug } from '#utils';
+import { feedback, generateTimestamp, getAbsoluteLibDirPath } from '#utils';
 import { Messages } from '#constants';
 
 const vulcanLibPath = getAbsoluteLibDirPath();
@@ -112,7 +112,6 @@ async function loadBuildContext(preset, entry, mode) {
     handlerFilePath = join(modePath, 'handler.js');
   }
 
-  // Convert file paths to file URLs
   configFilePath = new URL(`file://${configFilePath}`).href;
   prebuildFilePath = new URL(`file://${prebuildFilePath}`).href;
   

--- a/lib/platform/actions/core/auth.actions.js
+++ b/lib/platform/actions/core/auth.actions.js
@@ -45,7 +45,7 @@ async function auth(loginOption, credentials) {
       }
       if (responseJSON.token) {
         await vulcan.createVulcanEnv('API_TOKEN', responseJSON.token);
-        feedback.success(Messages.platform.auth.success.api_auth_success);
+        feedback.success(Messages.platform.auth.success.auth_success);
       }
     }
     if (loginOption === 'token') {

--- a/lib/platform/actions/core/propagation.actions.js
+++ b/lib/platform/actions/core/propagation.actions.js
@@ -1,6 +1,5 @@
 import { AzionEdges, Messages } from '#constants';
-import { feedback, debug } from '#utils';
-import open from 'open';
+import { feedback, debug, exec } from '#utils';
 /**
  * @function
  * @memberof platform
@@ -19,6 +18,8 @@ import open from 'open';
  *    console.error(error);
  * }
  */
+const isWindows = process.platform === 'win32';
+
 function watchPropagation(domain) {
   let currentEdgeIndex = 0;
   let intervalId = null;
@@ -38,13 +39,14 @@ function watchPropagation(domain) {
         clearInterval(intervalId);
 
         let remainingEdgeIndex = currentEdgeIndex + 1;
-        const remainingEdgesIntervalId = setInterval(() => {
+        const remainingEdgesIntervalId =  setInterval(async () => {
           if (remainingEdgeIndex >= AzionEdges.length) {
             clearInterval(remainingEdgesIntervalId);
             f.interactive.complete(
               Messages.platform.propagation.success.propagation_complete,
             );
-            open(`https://${domain}`);
+            await exec(`${isWindows ? 'start ' : 'open ' } https://${domain} `)
+
             process.exit(0);
           } else {
             const remainingEdge = AzionEdges[remainingEdgeIndex];

--- a/lib/platform/actions/core/storage.actions.js
+++ b/lib/platform/actions/core/storage.actions.js
@@ -43,7 +43,7 @@ async function uploadStatics(versionId, basePath, currentPath = '') {
     if (fileStat.isFile()) {
       const fileContent = await promisify(fs.readFile)(fullFilePath, 'utf8');
       const mimeType = mime.lookup(fullFilePath);
-      const staticPath = path.join(currentPath, filePath);
+      const staticPath = path.join(currentPath, filePath).replace(/\\/g, '/');
 
       try {
         const response = await StorageService.upload(versionId, fileContent, staticPath, mimeType);

--- a/lib/utils/getAbsoluteLibDirPath/getAbsoluteLibDirPath.utils.js
+++ b/lib/utils/getAbsoluteLibDirPath/getAbsoluteLibDirPath.utils.js
@@ -10,10 +10,20 @@
  * const libDirPath = getAbsoluteLibDirPath();
  * console.log(libDirPath); // "lib/full/path/to/directory"
  */
+
+const isWindows = process.platform === 'win32';
+
 function getAbsoluteLibDirPath() {
   const currentModuleFullPath = import.meta.url;
   let baselibPath = currentModuleFullPath.match(/(.*lib)(.*)/)[1];
-  baselibPath = baselibPath.replace('file://', '');
+  if (isWindows) {
+    baselibPath = new URL(baselibPath).pathname;
+    if (baselibPath.startsWith('/')) {
+      baselibPath = baselibPath.slice(1);
+    }
+  } else {
+    baselibPath = baselibPath.replace('file://', '');
+  }
 
   return baselibPath;
 }

--- a/lib/utils/getAbsoluteLibDirPath/getAbsoluteLibDirPath.utils.js
+++ b/lib/utils/getAbsoluteLibDirPath/getAbsoluteLibDirPath.utils.js
@@ -8,7 +8,7 @@
  *
  * // Example usage:
  * const libDirPath = getAbsoluteLibDirPath();
- * console.log(libDirPath); // "lib/full/path/to/directory"
+ * console.log(libDirPath); // 'lib/full/path/to/directory'
  */
 
 const isWindows = process.platform === 'win32';
@@ -21,7 +21,8 @@ function getAbsoluteLibDirPath() {
     if (baselibPath.startsWith('/')) {
       baselibPath = baselibPath.slice(1);
     }
-  } else {
+  }
+  if (!isWindows) {
     baselibPath = baselibPath.replace('file://', '');
   }
 

--- a/lib/utils/getPresetsList/getPresetsList.utils.js
+++ b/lib/utils/getPresetsList/getPresetsList.utils.js
@@ -15,7 +15,7 @@ import path from 'path';
  * // Output: ['Next (Static)', 'Next (Server)', 'Frodo (Nine Fingers)']
  */
 
-const isWindows = process.platform === 'win32'
+const isWindows = process.platform === 'win32';
 
 function getPresetsList(types = ['default', 'custom']) {
   const currentModuleFullPath = import.meta.url;
@@ -25,7 +25,8 @@ function getPresetsList(types = ['default', 'custom']) {
     if (baselibPath.startsWith('/')) {
       baselibPath = baselibPath.slice(1);
     }
-  } else {
+  }
+  if (!isWindows) {
     baselibPath = baselibPath.replace('file://', '');
   }
 
@@ -33,12 +34,16 @@ function getPresetsList(types = ['default', 'custom']) {
 
   types.forEach((type) => {
     const presetsDir = path.join(baselibPath, `presets/${type}`);
-    const folders = fs.readdirSync(presetsDir, { withFileTypes: true })
+    const folders = fs
+      .readdirSync(presetsDir, { withFileTypes: true })
 
       .filter((dirent) => dirent.isDirectory())
       .flatMap((dirent) => {
         const presetName = dirent.name;
-        const subDirs = fs.readdirSync(path.join(presetsDir, presetName), { withFileTypes: true })
+        const subDirs = fs
+          .readdirSync(path.join(presetsDir, presetName), {
+            withFileTypes: true,
+          })
           .filter((subDirent) => subDirent.isDirectory());
 
         if (subDirs.length === 0) {
@@ -46,8 +51,11 @@ function getPresetsList(types = ['default', 'custom']) {
         }
 
         return subDirs.map((subDir) => {
-          const subDirName = subDir.name.charAt(0).toUpperCase() + subDir.name.slice(1);
-          return `${presetName.charAt(0).toUpperCase() + presetName.slice(1)} (${subDirName})`;
+          const subDirName =
+            subDir.name.charAt(0).toUpperCase() + subDir.name.slice(1);
+          return `${
+            presetName.charAt(0).toUpperCase() + presetName.slice(1)
+          } (${subDirName})`;
         });
       });
 

--- a/lib/utils/getPresetsList/getPresetsList.utils.js
+++ b/lib/utils/getPresetsList/getPresetsList.utils.js
@@ -14,10 +14,20 @@ import path from 'path';
  * console.log(presetsList);
  * // Output: ['Next (Static)', 'Next (Server)', 'Frodo (Nine Fingers)']
  */
+
+const isWindows = process.platform === 'win32'
+
 function getPresetsList(types = ['default', 'custom']) {
   const currentModuleFullPath = import.meta.url;
   let baselibPath = currentModuleFullPath.match(/(.*lib)(.*)/)[1];
-  baselibPath = baselibPath.replace('file://', '');
+  if (isWindows) {
+    baselibPath = new URL(baselibPath).pathname;
+    if (baselibPath.startsWith('/')) {
+      baselibPath = baselibPath.slice(1);
+    }
+  } else {
+    baselibPath = baselibPath.replace('file://', '');
+  }
 
   const presets = [];
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "edge-functions",
   "type": "module",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Tool to launch and build JavaScript/Frameworks. This tool automates polyfills for Edge Computing and assists in creating Workers, notably for the Azion platform.",
   "main": "lib/main.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "mime-types": "^2.1.35",
     "node-polyfill-webpack-plugin": "^2.0.1",
     "npm": "^9.8.0",
-    "open": "^9.1.0",
     "pkg-dir": "^7.0.0",
     "semantic-release": "^21.0.7",
     "semver": "^7.5.2",


### PR DESCRIPTION
### Description:
These changes run vulkan on the Windows operating system, working with filesystems in the correct way that the system supports.

### Chore:

We will no longer need to use the open dependency of the package.json file, we will use exec for the task, as open does not execute the file as soon as the deploy is ready.

### Fixed:

- #### presets ls

![image](https://github.com/aziontech/vulcan/assets/12740219/100c59b8-7ae0-44f4-af32-f78748db06f3)

- #### prebuild
![image](https://github.com/aziontech/vulcan/assets/12740219/fe9ba9d2-ee7d-4b7b-89c0-2ec56bdee4e8)

- #### build
 
![image](https://github.com/aziontech/vulcan/assets/62527699/542aa54c-93bf-47d7-acb5-e5783e182229)

When running the deploy we have a problem with the core, as it is not able to read/find the files in the default url of the windows system, we will make some adjustments in the webpack, and in the core of the project, when completing the deploy and authentication process we found some errors that windows OS users.