### PR TITLE
[ISSUE-25] feat: local environment (server/runtime)

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -35,7 +35,7 @@ Each preset is made up of three primary files: `config.js`, `prebuild.js`, and `
 
 	- `getPackageManager`: This method returns the package manager relative to the user's project (can be yarn, npm, or pnpm).
 
-	- `copyDirectory`: This function is used to copy the resulting static files from the framework build to the local Edge environment (.edge/statics).
+	- `copyDirectory`: This function is used to copy the resulting static files from the framework build to the local Edge environment (.edge/storage).
 
 	- `feedback`: This interface is used to display messages during the process, if necessary, or in case of error.
 
@@ -83,7 +83,7 @@ Here's a step-by-step guide on how to add a new preset in Vulcan:
 	   This file serves as an extension to the edge build. It enables the inclusion of polyfills, plugins, or any other procedures that relate to the build process executed on the edge. Although it is editable, we strongly advise against making changes to this file unless absolutely necessary. It's designed to ensure optimal operation, and modifications should be undertaken with careful consideration.
 	   
 	   ## prebuild.js
-	   In this file, you should adapt the native build process of your framework or library. Usually, in the case of *deliver* presets, this file will be used to ensure that the generated static artifacts are placed in the *.edge/statics/* directory.
+	   In this file, you should adapt the native build process of your framework or library. Usually, in the case of *deliver* presets, this file will be used to ensure that the generated static artifacts are placed in the *.edge/storage/* directory.
       #### React (deliver) Example:
 
 ![prebuild](https://github.com/aziontech/vulcan/assets/12740219/85adc374-220b-4003-8c3e-6ec5b06a483f)

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -123,7 +123,7 @@ async function loadBuildContext(preset, entry, mode) {
   const edgehooksPath = await getAliasPath('edge');
   newEntryContent = newEntryContent.replace('#edge', edgehooksPath);
 
-  if (mode === 'mode') {
+  if (mode === 'compute') {
     const filePath = join(process.cwd(), entry);
     const entryContent = readFileSync(filePath, 'utf-8');
     newEntryContent = newEntryContent.replace('__JS_CODE__', entryContent);

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -123,7 +123,7 @@ async function loadBuildContext(preset, entry, mode) {
   const edgehooksPath = await getAliasPath('edge');
   newEntryContent = newEntryContent.replace('#edge', edgehooksPath);
 
-  if (mode === 'server') {
+  if (mode === 'mode') {
     const filePath = join(process.cwd(), entry);
     const entryContent = readFileSync(filePath, 'utf-8');
     newEntryContent = newEntryContent.replace('__JS_CODE__', entryContent);

--- a/lib/constants/messages/env.messages.js
+++ b/lib/constants/messages/env.messages.js
@@ -19,6 +19,8 @@ const env = {
       unknown_error: 'An error occurred while executing the script',
       fetch_event_missing: 'No fetch event handler was defined',
       fetch_event_unknown_error: 'An error occurred while handling the fetch event:',
+      fetch_event_remove_listener: 'Unable to remove event listener.',
+      fetch_event_type: (type) => `Unsupported event type: ${type}`,
       undefined_response: 'No response was defined',
     },
   },

--- a/lib/constants/messages/env.messages.js
+++ b/lib/constants/messages/env.messages.js
@@ -26,10 +26,10 @@ const env = {
   },
   server: {
     success: {
-      server_running: (port) => `Server running on port ${port}`,
+      server_running: (port) => `Function running on port ${port}`,
     },
     info: {
-      code_change_detect: 'Code change detected. Restarting server...',
+      code_change_detect: 'Code change detected. Restarting...',
     },
     errors: {
       load_worker_failed: 'Failed to load code:',

--- a/lib/constants/messages/env.messages.js
+++ b/lib/constants/messages/env.messages.js
@@ -32,7 +32,7 @@ const env = {
       code_change_detect: 'Code change detected. Restarting...',
     },
     errors: {
-      load_worker_failed: 'Failed to load code:',
+      load_worker_failed: (path) => `Failed load worker: ${path}`,
     },
   },
 };

--- a/lib/env/runtime.env.js
+++ b/lib/env/runtime.env.js
@@ -9,14 +9,14 @@ import mime from 'mime-types';
  * Modified fetch function that adds an additional path to the URL if it starts with 'file://'.
  * This function is used to simulate the local edge environment. When a 'file://' request is made,
  * it behaves as if the request is made from within the edge itself. In this case, an additional
- * '.edge/statics' folder is appended to the URL to represent the edge environment.
+ * '.edge/storage' folder is appended to the URL to represent the edge environment.
  * @param {URL} url - The URL to fetch.
  * @param {object} [options] - The fetch options.
  * @returns {Promise<Response>} A Promise that resolves to the Response object.
  */
 function runtimeFetch(url, options) {
   if (url.href.startsWith('file://')) {
-    const filePath = join(process.cwd(), '.edge', 'statics', url.pathname.slice(1));
+    const filePath = join(process.cwd(), '.edge', 'storage', url.pathname.slice(1));
     const fileContent = readFileSync(filePath);
     const contentType = mime.lookup(filePath) || 'application/octet-stream';
     const response = new Response(fileContent, { headers: { 'Content-Type': contentType }, ...options });

--- a/lib/env/runtime.env.js
+++ b/lib/env/runtime.env.js
@@ -16,37 +16,46 @@ import mime from 'mime-types';
  */
 function runtimeFetch(url, options) {
   if (url.href.startsWith('file://')) {
-    const filePath = join(process.cwd(), '.edge', 'storage', url.pathname.slice(1));
+    const segments = url.pathname.split('/').filter(Boolean);
+    const filePath = join(process.cwd(), '.edge', 'storage', segments.slice(1).join('/'));
     const fileContent = readFileSync(filePath);
     const contentType = mime.lookup(filePath) || 'application/octet-stream';
-    const response = new Response(fileContent, { headers: { 'Content-Type': contentType }, ...options });
+
+    const headers = new Headers();
+    headers.append('Content-Type', contentType);
+
+    const response = new Response(fileContent, { headers, ...options });
     return Promise.resolve(response);
   }
   return fetch(url, options);
 }
 
 /**
- * Execute the specified code with the provided event object.
+ * Executes the specified JavaScript code within a sandbox environment,
+ * simulating the behavior of edges that use isolates.
  * @async
  * @param {string} code - The JavaScript code to be executed.
  * @param {object} event - The event object containing the request and other properties.
- * @returns {Promise<object>} A Promise that resolves with the Response object.
+ * @returns {Promise<Response>} A Promise that resolves with the Response object.
  * @throws {Error} Will throw an error if the execution fails.
- * @description Executes the specified code within a sandbox
- * environment and handles the fetch event.
+ * @description This runtime module is a JavaScript executor created in Node.js,
+ * simulating the behavior of edges isolates to work locally.
+ * It provides a sandbox environment similar to the Azion edges (running Deno),
+ *  supporting Web APIs/WinterCG.
  * @example
  * try {
  *    const code = 'console.log("Hello, world!");';
  *    const event = { request: ... };
- *    const response = await run(code, event);
+ *    const response = await runtime(code, event);
  *    console.log(response);
  * } catch (error) {
  *    console.error(error);
  * }
  */
-async function run(code, event) {
+async function runtime(code, event) {
   let fetchEventHandler = null;
   let respondWithPromise = null;
+  const waitUntilPromises = []; // Array para armazenar as promessas do waitUntil
 
   const vm = new NodeVM({
     console: 'inherit',
@@ -79,7 +88,7 @@ async function run(code, event) {
     vm.run(code);
   } catch (error) {
     debug.error(error);
-    feedback.error(Messages.env.runtime.errors.unknown_error);
+    feedback.runtime.error(Messages.env.runtime.errors.unknown_error);
     throw error;
   }
 
@@ -94,12 +103,17 @@ async function run(code, event) {
       respondWith: (responsePromise) => {
         respondWithPromise = responsePromise;
       },
+      waitUntil: (promise) => {
+        waitUntilPromises.push(promise);
+      },
+      console: { log: (log) => feedback.server.log(log) },
     };
     fetchEventHandler(fetchEvent);
     response = respondWithPromise;
+    await Promise.all(waitUntilPromises);
   } catch (error) {
     debug.error(error);
-    feedback.error(Messages.env.runtime.errors.fetch_event_unknown_error);
+    feedback.runtime.error(Messages.env.runtime.errors.fetch_event_unknown_error);
     throw error;
   }
 
@@ -110,4 +124,4 @@ async function run(code, event) {
   return response;
 }
 
-export default run;
+export default runtime;

--- a/lib/env/runtime.env.js
+++ b/lib/env/runtime.env.js
@@ -1,12 +1,48 @@
 import { NodeVM } from 'vm2';
+import { join } from 'path';
+import { readFileSync } from 'fs';
 import { RuntimeApis, Messages } from '#constants';
 import { feedback, debug } from '#utils';
+import mime from 'mime-types';
+
+/**
+ * Modified fetch function that adds an additional path to the URL if it starts with 'file://'.
+ * This function is used to simulate the local edge environment. When a 'file://' request is made,
+ * it behaves as if the request is made from within the edge itself. In this case, an additional
+ * '.edge/statics' folder is appended to the URL to represent the edge environment.
+ * @param {URL} url - The URL to fetch.
+ * @param {object} [options] - The fetch options.
+ * @returns {Promise<Response>} A Promise that resolves to the Response object.
+ */
+function runtimeFetch(url, options) {
+  if (url.href.startsWith('file://')) {
+    const filePath = join(process.cwd(), '.edge', 'statics', url.pathname.slice(1));
+    const fileContent = readFileSync(filePath);
+    const contentType = mime.lookup(filePath) || 'application/octet-stream';
+    const response = new Response(fileContent, { headers: { 'Content-Type': contentType }, ...options });
+    return Promise.resolve(response);
+  }
+  return fetch(url, options);
+}
 
 /**
  * Execute the specified code with the provided event object.
+ * @async
  * @param {string} code - The JavaScript code to be executed.
  * @param {object} event - The event object containing the request and other properties.
  * @returns {Promise<object>} A Promise that resolves with the Response object.
+ * @throws {Error} Will throw an error if the execution fails.
+ * @description Executes the specified code within a sandbox
+ * environment and handles the fetch event.
+ * @example
+ * try {
+ *    const code = 'console.log("Hello, world!");';
+ *    const event = { request: ... };
+ *    const response = await run(code, event);
+ *    console.log(response);
+ * } catch (error) {
+ *    console.error(error);
+ * }
  */
 async function run(code, event) {
   let fetchEventHandler = null;
@@ -15,14 +51,22 @@ async function run(code, event) {
   const vm = new NodeVM({
     console: 'inherit',
     sandbox: {
-      Headers,
       ...event,
+      Headers,
+      URL,
+      fetch: runtimeFetch,
       Response,
       addEventListener: (type, handler) => {
         if (type !== 'fetch') {
-          throw new Error(`Unsupported event type: ${type}`);
+          throw new Error(Messages.env.runtime.errors.fetch_event_type(type));
         }
         fetchEventHandler = handler;
+      },
+      removeEventListener: (type, handler) => {
+        if (type !== 'fetch' || fetchEventHandler !== handler) {
+          throw new Error(Messages.env.runtime.errors.fetch_event_remove_listener);
+        }
+        fetchEventHandler = null;
       },
     },
     require: {

--- a/lib/env/server.env.js
+++ b/lib/env/server.env.js
@@ -18,7 +18,7 @@ function createServer(filePath) {
     const isStaticAsset = extname(pathname) !== '';
 
     if (isStaticAsset) {
-      const staticFilePath = join(process.cwd(), '.edge', 'statics', pathname);
+      const staticFilePath = join(process.cwd(), '.edge', 'storage', pathname);
       const fileContent = readFileSync(staticFilePath);
       const contentType = mime.lookup(staticFilePath) || 'application/octet-stream';
 

--- a/lib/env/server.env.js
+++ b/lib/env/server.env.js
@@ -1,49 +1,48 @@
 import http from 'http';
 import chokidar from 'chokidar';
-import { join, extname } from 'path';
-import { readFileSync } from 'fs';
-import { debug, feedback, readWorkerFile } from '#utils';
+import { join } from 'path';
+import {
+  debug, feedback, readWorkerFile, exec,
+} from '#utils';
 import { Messages } from '#constants';
-import mime from 'mime-types';
-import run from './runtime.env.js';
+import runtime from './runtime.env.js';
+
+let server = null;
+let workerCode = null;
 
 /**
- * Create a new HTTP server.
- * @param {string} filePath - The path to the file containing the code.
- * @returns {http.Server} The created server.
+ * Read the worker code from the file.
+ * @param {string} workerPath - The path to the file containing the code.
+ * @returns {Promise<string>} A promise that resolves to the worker code.
  */
-function createServer(filePath) {
-  return http.createServer(async (request, response) => {
-    const { pathname } = new URL(request.url, 'http://localhost');
-    const isStaticAsset = extname(pathname) !== '';
+async function readWorkerCode(workerPath) {
+  try {
+    const worker = await readWorkerFile(workerPath);
+    return worker;
+  } catch (error) {
+    debug.error(error);
+    throw error;
+  }
+}
 
-    if (isStaticAsset) {
-      const staticFilePath = join(process.cwd(), '.edge', 'storage', pathname);
-      const fileContent = readFileSync(staticFilePath);
-      const contentType = mime.lookup(staticFilePath) || 'application/octet-stream';
+/**
+ * Create or update the HTTP server with the new code.
+ * @param {string} newCode - The new worker code.
+ * @returns {http.Server} The updated server.
+ */
+function createOrUpdateServer(newCode) {
+  if (server) {
+    server.close();
+  }
 
-      response.statusCode = 200;
-      response.setHeader('Content-Type', contentType);
-      response.end(fileContent);
-      return;
-    }
-
-    let code;
-
+  server = http.createServer(async (request, response) => {
     try {
-      // Load the code to be executed on the server for each request
-      console.log('ha');
-      code = await readWorkerFile(filePath);
-    } catch (error) {
-      debug.error(error);
-      response.statusCode = 500;
-      response.setHeader('Content-Type', 'text/plain');
-      response.end(JSON.stringify({ error: error.message }));
-      return;
-    }
+      const baseUrl = request.headers.host;
+      const url = new URL(request.url, `http://${baseUrl}`);
+      const fullPath = join(url.origin, url.pathname);
+      request.url = fullPath;
 
-    try {
-      const responseBody = await run(code, { request, response });
+      const responseBody = await runtime(newCode, { request, response });
 
       if (responseBody instanceof Response) {
         responseBody.headers.forEach((value, name) => {
@@ -66,39 +65,52 @@ function createServer(filePath) {
 
       error.message = errorMessage;
       debug.error(error);
-      feedback.error(Messages.env.server.errors.load_worker_failed);
+      feedback.server.error((errorMessage));
       response.statusCode = 500;
       response.setHeader('Content-Type', 'text/plain');
       response.end(JSON.stringify({ error: { message: errorMessage, status: 500 } }));
     }
   });
+
+  return server;
 }
 
 /**
  * Start the HTTP server with the specified port and file path to load the code from.
- * @param {string} filePath - The path to the file containing the code.
+ * @param {string} workerPath - The path to the file containing the worker code.
  * @param {number} port - The port to listen on.
- * @returns {http.Server} The created server.
+ * @returns {http.Server} The created or updated server.
  */
-async function startServer(filePath, port) {
-  let server = createServer(filePath);
+async function startServer(workerPath, port) {
+  try {
+    workerCode = await readWorkerCode(workerPath);
+  } catch (error) {
+    debug.error(error);
+    feedback.server.error(Messages.env.server.errors.load_worker_failed(workerPath));
+    return null;
+  }
+
+  server = createOrUpdateServer(workerCode);
 
   // Use chokidar to watch for changes in the file
-  const watcher = chokidar.watch(filePath);
+  const watcher = chokidar.watch(workerPath);
 
   watcher.on('change', async () => {
-    feedback.info(Messages.env.server.info.code_change_detect);
-    // Close the current server
-    server.close();
-    // And create a new one
-    server = createServer(filePath);
-    server.listen(port, () => {
-      feedback.success(Messages.env.server.success.server_running(port));
-    });
+    feedback.server.info(Messages.env.server.info.code_change_detect);
+    try {
+      workerCode = await readWorkerCode(workerPath);
+      server = createOrUpdateServer(workerCode);
+      server.listen(port, () => {});
+    } catch (error) {
+      debug.error(error);
+      feedback.server.error(Messages.env.server.errors.load_worker_failed(workerPath));
+    }
   });
 
   server.listen(port, () => {
-    feedback.success(Messages.env.server.success.server_running(port));
+    const isWindows = process.platform === 'win32';
+    exec(`${isWindows ? 'start ' : 'open '} http://localhost:${port} `);
+    feedback.server.success(Messages.env.server.success.server_running(port));
   });
 
   return server;

--- a/lib/env/server.env.js
+++ b/lib/env/server.env.js
@@ -1,8 +1,10 @@
 import http from 'http';
 import chokidar from 'chokidar';
-
+import { join, extname } from 'path';
+import { readFileSync } from 'fs';
 import { debug, feedback, readWorkerFile } from '#utils';
 import { Messages } from '#constants';
+import mime from 'mime-types';
 import run from './runtime.env.js';
 
 /**
@@ -12,10 +14,25 @@ import run from './runtime.env.js';
  */
 function createServer(filePath) {
   return http.createServer(async (request, response) => {
+    const { pathname } = new URL(request.url, 'http://localhost');
+    const isStaticAsset = extname(pathname) !== '';
+
+    if (isStaticAsset) {
+      const staticFilePath = join(process.cwd(), '.edge', 'statics', pathname);
+      const fileContent = readFileSync(staticFilePath);
+      const contentType = mime.lookup(staticFilePath) || 'application/octet-stream';
+
+      response.statusCode = 200;
+      response.setHeader('Content-Type', contentType);
+      response.end(fileContent);
+      return;
+    }
+
     let code;
 
     try {
       // Load the code to be executed on the server for each request
+      console.log('ha');
       code = await readWorkerFile(filePath);
     } catch (error) {
       debug.error(error);

--- a/lib/main.js
+++ b/lib/main.js
@@ -157,14 +157,14 @@ function startVulcanProgram() {
     program
       .command('storage sync')
       .description(
-        'Synchronize local .edge/statics with the Edge Function storage',
+        'Synchronize local .edge/storage with the Edge Function storage',
       )
       .action(async () => {
         const { core } = await import('#platform');
         const { getVulcanBuildId } = await import('#utils');
 
         const versionId = getVulcanBuildId();
-        const basePath = path.join(process.cwd(), '.edge/statics/');
+        const basePath = path.join(process.cwd(), '.edge/storage/');
         await core.actions.uploadStatics(versionId, basePath);
       });
 
@@ -176,7 +176,7 @@ function startVulcanProgram() {
         const { getVulcanBuildId } = await import('#utils');
 
         const versionId = getVulcanBuildId();
-        const staticsPath = path.join(process.cwd(), '/.edge/statics');
+        const staticsPath = path.join(process.cwd(), '/.edge/storage');
 
         const answers = await prompt([
           {

--- a/lib/main.js
+++ b/lib/main.js
@@ -123,13 +123,13 @@ function startVulcanProgram() {
     program
       .command('run')
       .description('Run Edge Function')
-      .arguments('<file>')
+      .arguments('[file]')
       .option('-p, --port <port>', 'Specify the port', '3000')
       .action(async (file, options) => {
         const { port } = options;
         const parsedPort = parseInt(port, 10);
         const { server } = await import('#env');
-        const entryPoint = file || path.join(process.cwd(), '.edge/woker.js');
+        const entryPoint = file || path.join(process.cwd(), '.edge/worker.js');
         server(entryPoint, parsedPort);
       });
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -121,50 +121,16 @@ function startVulcanProgram() {
       });
 
     program
-      .command('run')
-      .description('Run Edge Function')
-      .arguments('[file]')
-      .option('-p, --port <port>', 'Specify the port', '3000')
-      .action(async (file, options) => {
-        const { port } = options;
-        const parsedPort = parseInt(port, 10);
-        const { server } = await import('#env');
-        const entryPoint = file || path.join(process.cwd(), '.edge/worker.js');
-        server(entryPoint, parsedPort);
-      });
-
-    program
-      .command('logs <type> [id]')
-      .description('Perform operations on function or application logs')
-      .option('-w, --watch', 'Show real-time logs')
-      .action(async (type, id, options) => {
-        const { functions } = await import('#platform');
-        const { watch } = options;
-
-        if (!['function', 'application'].includes(type)) {
-          feedback.error(Messages.platform.logs.errors.invalid_log_type);
-          return;
-        }
-
-        if (type === 'function') {
-          functions.actions.showFunctionLogs(id, watch);
-        }
-        if (type === 'application') {
-          feedback.info(Messages.platform.logs.info.unsupported_log_type);
-        }
-      });
-
-    program
       .command('storage sync')
       .description(
-        'Synchronize local .edge/storage with the Edge Function storage',
+        'Synchronize local .edge/statics with the Edge Function storage',
       )
       .action(async () => {
         const { core } = await import('#platform');
         const { getVulcanBuildId } = await import('#utils');
 
         const versionId = getVulcanBuildId();
-        const basePath = path.join(process.cwd(), '.edge/storage/');
+        const basePath = path.join(process.cwd(), '.edge/statics/');
         await core.actions.uploadStatics(versionId, basePath);
       });
 
@@ -176,7 +142,7 @@ function startVulcanProgram() {
         const { getVulcanBuildId } = await import('#utils');
 
         const versionId = getVulcanBuildId();
-        const staticsPath = path.join(process.cwd(), '/.edge/storage');
+        const staticsPath = path.join(process.cwd(), '/.edge/statics');
 
         const answers = await prompt([
           {
@@ -201,6 +167,39 @@ function startVulcanProgram() {
       });
   }
 
+  program
+    .command('run')
+    .description('Run Edge Function')
+    .arguments('[file]')
+    .option('-p, --port <port>', 'Specify the port', '3000')
+    .action(async (file, options) => {
+      const { port } = options;
+      const parsedPort = parseInt(port, 10);
+      const { server } = await import('#env');
+      const entryPoint = file || path.join(process.cwd(), '.edge/worker.js');
+      server(entryPoint, parsedPort);
+    });
+
+  program
+    .command('logs <type> [id]')
+    .description('Perform operations on function or application logs')
+    .option('-w, --watch', 'Show real-time logs')
+    .action(async (type, id, options) => {
+      const { functions } = await import('#platform');
+      const { watch } = options;
+
+      if (!['function', 'application'].includes(type)) {
+        feedback.error(Messages.platform.logs.errors.invalid_log_type);
+        return;
+      }
+
+      if (type === 'function') {
+        functions.actions.showFunctionLogs(id, watch);
+      }
+      if (type === 'application') {
+        feedback.info(Messages.platform.logs.info.unsupported_log_type);
+      }
+    });
   program
     .command('build')
     .description('Build a project for edge deployment')

--- a/lib/platform/actions/function/showFunctionLogs.actions.js
+++ b/lib/platform/actions/function/showFunctionLogs.actions.js
@@ -5,36 +5,19 @@ import eventsService from '../../services/events.service.js';
 /**
  *
  * @param {object} log - View logs organized in a box.
- * @param {boolean} [watch=false] - Whether to observe logs in real time.
  */
-function displayLogInBox(log, watch = false) {
-  const functionIdLabel = 'Function ID:';
-  const dateLabel = 'Date:';
-  const eventIdLabel = 'Event ID:';
-  const functionIdLine = `${functionIdLabel} ${log.functionId}`;
-  const dateLine = `${dateLabel} ${log.date}`;
-  const eventIdLine = `${eventIdLabel} ${log.eventId}`;
-  const maxLength = Math.max(
-    functionIdLine.length,
-    dateLine.length,
-    eventIdLine.length,
-    ...log.logs.map((line) => line.length),
-  );
-  const horizontalLine = '═'.repeat(maxLength + 2);
-
-  console.log(`╔${horizontalLine}╗`);
-  console.log(`║ ${functionIdLine.padEnd(maxLength)} ║`);
-  console.log(`║ ${eventIdLine.padEnd(maxLength)} ║`);
-  console.log(`║ ${dateLine.padEnd(maxLength)} ║`);
-  console.log(`╠${horizontalLine}╣`);
-  log.logs.forEach((line) => {
-    console.log(`║ ${line.padEnd(maxLength)} ║`);
+function displayLogInBox(log) {
+  log.logLines.forEach((line) => {
+    try {
+      const trimmedLine = line.trim();
+      const parsedJSON = JSON.parse(trimmedLine);
+      const formattedJSON = JSON.stringify(parsedJSON, null, 2);
+      feedback.logs(log.functionId, log.eventId, log.date.toLocaleString()).debug(`\n${formattedJSON}`);
+    } catch (error) {
+      console.log(error);
+      feedback.logs(`Function ID: ${log.functionId}`, log.eventId, log.date.toLocaleString()).debug(`\n${line}`);
+    }
   });
-  console.log(`╚${horizontalLine}╝`);
-
-  if (watch) {
-    console.log(Messages.platform.logs.info.watch_true);
-  }
 }
 
 /**
@@ -60,90 +43,86 @@ function displayLogInBox(log, watch = false) {
  * showFunctionLogs();
  */
 async function showFunctionLogs(functionId, watch = false) {
-  let previousConsoleLogId = null;
+  let watchStartTime = new Date();
+  let logsToDisplay = {};
 
   /**
    * Mounts the structure for a console log.
    * @param {object} azionLog - The Azion log event.
-   * @param {string} azionLog.id - The ID of the  event.
+   * @param {string} azionLog.id - The ID of the event.
    * @param {string} azionLog.ts - The timestamp of the event.
    * @returns {object} - The log event structure.
    * @property {string} eventId - The ID of the event.
-   * @property {string} date - The formatted date of the event.
-   * @property {string[]} logs - The array of log messages.
+   * @property {string} functionId - The ID of the function.
+   * @property {Date} date - The date object of the event.
+   * @property {string[]} logLines - The array of log lines.
    */
-  const mountEventLogStructure = (azionLog) => ({
-    eventId: azionLog.id,
-    functionId: azionLog.functionId,
-    date: new Date(azionLog.ts).toLocaleString(),
-    logs: [],
-  });
+  function mountEventLogStructure(azionLog) {
+    return {
+      eventId: azionLog.id,
+      functionId: azionLog.functionId,
+      date: new Date(azionLog.ts),
+      logLines: [],
+    };
+  }
 
-  /**
-   * Internal function for performing polling and retrieving function logs.
-   * @returns {void}
-   */
-  const startPoll = async () => {
-    try {
+  try {
+    const getLogs = async () => {
       const response = await eventsService.getFunctionsLogs(functionId);
-      const responseJSON = await response.json();
-      const { cellsConsoleEvents } = responseJSON.data;
-      const requestSuccess = !!cellsConsoleEvents;
 
-      if (!requestSuccess) {
-        throw new Error(JSON.stringify(responseJSON));
-      }
-      if (requestSuccess) {
-        const nextConsoleLog = cellsConsoleEvents.length > 0 ? cellsConsoleEvents[0] : null;
+      if (response.status === 200) {
+        const responseJSON = await response.json();
 
-        if (!nextConsoleLog) {
-          feedback.info(Messages.platform.logs.info.no_logs);
+        const { cellsConsoleEvents } = responseJSON.data;
+        const requestSuccess = !!cellsConsoleEvents;
+
+        if (!requestSuccess) {
+          throw new Error(JSON.stringify(responseJSON));
         }
-        if (nextConsoleLog) {
-          if (nextConsoleLog?.id !== previousConsoleLogId) {
-            if (watch) {
-              const event = mountEventLogStructure(nextConsoleLog);
-              // eslint-disable-next-line max-len
-              const logsGroupedByRequest = cellsConsoleEvents.filter((item) => item.id === nextConsoleLog.id);
-              logsGroupedByRequest.forEach((log) => {
-                event.logs.push(log.line);
-              });
-              displayLogInBox(event, watch);
-              previousConsoleLogId = nextConsoleLog.id;
-            }
 
-            if (!watch) {
-              const logsGroupedByRequest = Object.values(cellsConsoleEvents
-                .reduce((result, event) => {
-                  const { id, line } = event;
-
-                  if (!result[id]) {
-                  // eslint-disable-next-line no-param-reassign
-                    result[id] = mountEventLogStructure(event);
-                  }
-
-                  result[id].logs.push(line);
-
-                  return result;
-                }, {}));
-
-              logsGroupedByRequest.forEach((log) => {
-                displayLogInBox(log, watch);
-              });
-            }
+        if (watch) {
+          if (watch) {
+            feedback.watch(Messages.platform.logs.info.watch_true);
           }
+          logsToDisplay = {}; // Clear logsToDisplay on each poll when in watch mode
         }
+
+        cellsConsoleEvents.forEach((event) => {
+          const { id, line, ts } = event;
+          const eventDate = new Date(ts);
+
+          if (watch && eventDate < watchStartTime) {
+            return; // Skip logs that are older than watchStartTime
+          }
+
+          if (!logsToDisplay[id]) {
+            logsToDisplay[id] = mountEventLogStructure(event);
+          }
+
+          logsToDisplay[id].logLines.push(line);
+          logsToDisplay[id].date = eventDate;
+        });
+
+        Object.values(logsToDisplay).forEach((log) => {
+          displayLogInBox(log, watch);
+        });
+
+        watchStartTime = new Date();
       }
 
       if (watch) {
-        setTimeout(startPoll, 500);
+        setTimeout(getLogs, 3000);
       }
-    } catch (error) {
-      debug.error(error);
-    }
-  };
+    };
 
-  startPoll();
+    getLogs();
+  } catch (error) {
+    debug.error(error);
+  }
 }
+
+process.on('exit', () => {
+  feedback.interactive.breakInteractiveChain();
+});
 
 export default showFunctionLogs;

--- a/lib/platform/edgehooks/debugRequest/debugRequest.hooks.js
+++ b/lib/platform/edgehooks/debugRequest/debugRequest.hooks.js
@@ -1,0 +1,28 @@
+/**
+ * @function
+ * @name DebugRequest
+ * @memberof edge
+ * @description
+ * The `DebugRequest` function is used to debug and display the details of an incoming request.
+ * It takes the request as a parameter and logs the request URL, method, and headers to the console.
+ * @param {FetchEvent} event - The incoming FetchEvent object.
+ * @returns {Promise<void>} A promise that resolves once the request details are logged.
+ */
+async function DebugRequest(event) {
+  const { request } = event;
+  const headers = new Headers(request.headers);
+
+  const requestData = {
+    url: request.url,
+    method: request.method,
+    headers: {},
+  };
+
+  headers.forEach((value, name) => {
+    requestData.headers[name] = value;
+  });
+
+  return event.console.log(requestData);
+}
+
+export default DebugRequest;

--- a/lib/platform/edgehooks/debugRequest/index.js
+++ b/lib/platform/edgehooks/debugRequest/index.js
@@ -1,0 +1,3 @@
+import debugRequest from './debugRequest.hooks.js';
+
+export default debugRequest;

--- a/lib/platform/edgehooks/index.js
+++ b/lib/platform/edgehooks/index.js
@@ -1,5 +1,8 @@
+import debugRequest from './debugRequest/debugRequest.hooks.js';
 import mountSPA from './mountSPA/mountSPA.hooks.js';
 import mountSSG from './mountSSG/mountSSG.hooks.js';
 import ErrorHTML from './ErrorHTML/ErrorHTML.hooks.js';
 
-export { mountSPA, mountSSG, ErrorHTML };
+export {
+  debugRequest, mountSPA, mountSSG, ErrorHTML,
+};

--- a/lib/presets/custom/angular/deliver/handler.js
+++ b/lib/presets/custom/angular/deliver/handler.js
@@ -1,6 +1,7 @@
-import { mountSPA, ErrorHTML } from '#edge';
+import { mountSPA, debugRequest, ErrorHTML } from '#edge';
 
 try {
+  debugRequest(event);
   const myApp = await mountSPA(event.request.url, AZION.VERSION_ID);
   return myApp;
 } catch (e) {

--- a/lib/presets/custom/angular/deliver/prebuild.js
+++ b/lib/presets/custom/angular/deliver/prebuild.js
@@ -11,7 +11,7 @@ async function prebuild() {
     // after the script as options for npm itself, not the script itself.
     const npmArgsForward = packageManager === 'npm' ? '--' : '';
     // support npm, yarn, pnpm
-    await exec(`${packageManager} run build ${npmArgsForward} --output-path=.edge/statics`, 'Angular', true);
+    await exec(`${packageManager} run build ${npmArgsForward} --output-path=.edge/storage`, 'Angular', true);
   } catch (error) {
     feedback.prebuild.error(error);
   }

--- a/lib/presets/custom/astro/deliver/handler.js
+++ b/lib/presets/custom/astro/deliver/handler.js
@@ -1,6 +1,7 @@
-import { mountSSG, ErrorHTML } from "#edge";
+import { mountSSG, debugRequest, ErrorHTML } from "#edge";
 
 try {
+  debugRequest(event);
   const myApp = await mountSSG(event.request.url, AZION.VERSION_ID);
   return myApp;
 } catch (error) {

--- a/lib/presets/custom/astro/deliver/prebuild.js
+++ b/lib/presets/custom/astro/deliver/prebuild.js
@@ -10,7 +10,7 @@ const packageManager = await getPackageManager();
  */
 async function prebuild() {
   try {
-    const newOutDir = '.edge/statics';
+    const newOutDir = '.edge/storage';
     let outDir = 'dist';
 
     // check if an output path is specified in config file

--- a/lib/presets/custom/hexo/deliver/handler.js
+++ b/lib/presets/custom/hexo/deliver/handler.js
@@ -1,6 +1,7 @@
-import { mountSSG, ErrorHTML } from "#edge";
+import { mountSSG, debugRequest, ErrorHTML } from "#edge";
 
 try {
+  debugRequest(event);
   const myApp = await mountSSG(event.request.url, AZION.VERSION_ID);
   return myApp;
 } catch (e) {

--- a/lib/presets/custom/hexo/deliver/prebuild.js
+++ b/lib/presets/custom/hexo/deliver/prebuild.js
@@ -10,7 +10,7 @@ const packageManager = await getPackageManager();
  */
 async function prebuild() {
   try {
-    const newOutDir = '.edge/statics';
+    const newOutDir = '.edge/storage';
     let outDir = 'public';
 
     // check if an output path is specified in config file

--- a/lib/presets/custom/next/deliver/config.js
+++ b/lib/presets/custom/next/deliver/config.js
@@ -5,7 +5,7 @@ const config = {
   builder: 'webpack',
   webpack: {
     config: {
-      distDir: '.edge/statics',
+      distDir: '.edge/storage',
     },
     plugins: [],
   },

--- a/lib/presets/custom/next/deliver/handler.js
+++ b/lib/presets/custom/next/deliver/handler.js
@@ -1,6 +1,7 @@
-import { mountSSG } from "#edge";
+import { mountSSG, debugRequest } from "#edge";
 
 try {
+  debugRequest(event);
   const myApp = await mountSSG(event.request.url, AZION.VERSION_ID);
   return myApp;
 } catch (e) {

--- a/lib/presets/custom/next/deliver/prebuild.js
+++ b/lib/presets/custom/next/deliver/prebuild.js
@@ -167,7 +167,7 @@ async function prebuild() {
         outDir = attributeMatch[1].trim().replace(/["']/g, '');
       }
 
-      await exec(`${packageManager} run build`, true);
+      await exec(`${packageManager} run build`, `Next ${nextVersion}`, true);
 
       // move files to vulcan default path
       copyDirectory(outDir, staticsOutputDir);
@@ -176,9 +176,9 @@ async function prebuild() {
       feedback.prebuild.info('Adapting Next.js build output...');
       await moveFiles(`${process.cwd()}/${staticsOutputDir}`);
     } else {
-      await exec(`${packageManager} run build`, true);
+      await exec(`${packageManager} run build`, `Next ${nextVersion}`, true);
 
-      await exec(`npx next export -o ${staticsOutputDir}`, true);
+      await exec(`npx next export -o ${staticsOutputDir}`, `Next ${nextVersion}`, true);
 
       feedback.prebuild.info('Adapting Next.js build output...');
       await moveFiles(`${process.cwd()}/${staticsOutputDir}`);

--- a/lib/presets/custom/next/deliver/prebuild.js
+++ b/lib/presets/custom/next/deliver/prebuild.js
@@ -26,11 +26,11 @@ const packageManager = await getPackageManager();
  * @param {string} directory - The root directory to start moving files.
  * @example
  * // Before:
- * // Root directory: '/path/to/project/.edge/statics'
+ * // Root directory: '/path/to/project/.edge/storage'
  * // Files in the directory: ['home.html', 'about.html', 'contact.html', 'styles.css']
  *
- * // After calling moveFiles('/path/to/project/.edge/statics'):
- * // Root directory: '/path/to/project/.edge/statics'
+ * // After calling moveFiles('/path/to/project/.edge/storage'):
+ * // Root directory: '/path/to/project/.edge/storage'
  * // Files in the directory: ['styles.css']
  * // Subdirectory 'home':
  * //   - index.html (previously home.html)
@@ -148,7 +148,7 @@ async function prebuild() {
     const nextVersion = getPackageVersion('next');
     feedback.prebuild.info('Detected Next.js version:', nextVersion);
 
-    const staticsOutputDir = '.edge/statics';
+    const staticsOutputDir = '.edge/storage';
 
     if (isANewerVersion(nextVersion)) {
       const nextConfig = await getNextConfig();

--- a/lib/presets/custom/react/deliver/handler.js
+++ b/lib/presets/custom/react/deliver/handler.js
@@ -1,6 +1,7 @@
-import { mountSPA, ErrorHTML } from "#edge";
+import { mountSPA, debugRequest, ErrorHTML } from "#edge";
 
   try {
+    debugRequest(event);
     const myApp = await mountSPA(event.request.url, AZION.VERSION_ID);
     return myApp;
   } catch (e) {

--- a/lib/presets/custom/react/deliver/prebuild.js
+++ b/lib/presets/custom/react/deliver/prebuild.js
@@ -7,7 +7,7 @@ const packageManager = await getPackageManager();
  */
 async function prebuild() {
   try {
-    await exec(`BUILD_PATH="./.edge/statics" ${packageManager} run build`, 'React', true);
+    await exec(`BUILD_PATH="./.edge/storage" ${packageManager} run build`, 'React', true);
   } catch (error) {
     feedback.prebuild.error(error);
   }

--- a/lib/presets/custom/vue/deliver/handler.js
+++ b/lib/presets/custom/vue/deliver/handler.js
@@ -1,6 +1,7 @@
-import { mountSPA, ErrorHTML } from "#edge";
+import { mountSPA, debugRequest, ErrorHTML } from "#edge";
 
   try {
+    debugRequest(event);
     const myApp = await mountSPA(event.request.url, AZION.VERSION_ID);
     return myApp;
   } catch (e) {

--- a/lib/presets/custom/vue/deliver/prebuild.js
+++ b/lib/presets/custom/vue/deliver/prebuild.js
@@ -11,7 +11,7 @@ async function prebuild() {
     // after the script as options for npm itself, not the script itself.
     const npmArgsForward = packageManager === 'npm' ? '--' : '';
     // support npm, yarn, pnpm
-    await exec(`${packageManager} run build ${npmArgsForward} --dest .edge/statics`, 'Vue', true);
+    await exec(`${packageManager} run build ${npmArgsForward} --dest .edge/storage`, 'Vue', true);
   } catch (error) {
     feedback.prebuild.error(error);
   }

--- a/lib/presets/default/html/deliver/handler.js
+++ b/lib/presets/default/html/deliver/handler.js
@@ -1,6 +1,7 @@
-import { mountSSG } from "#edge";
+import { mountSSG, debugRequest } from "#edge";
 
 try {
+  debugRequest(event)
   const myApp = await mountSSG(event.request.url, AZION.VERSION_ID);
   return myApp;
 } catch (e) {

--- a/lib/presets/default/html/deliver/prebuild.js
+++ b/lib/presets/default/html/deliver/prebuild.js
@@ -7,7 +7,7 @@ import { copyDirectory } from '#utils';
  */
 async function prebuild() {
   const sourceDir = process.cwd();
-  const targetDir = join('.', '.edge', 'statics');
+  const targetDir = join('.', '.edge', 'storage');
 
   copyDirectory(sourceDir, targetDir);
 }

--- a/lib/presets/default/javascript/compute/handler.js
+++ b/lib/presets/default/javascript/compute/handler.js
@@ -1,4 +1,7 @@
+import { debugRequest } from "#edge";
+
 try {
+  debugRequest(event)
   __JS_CODE__;
 } catch (e) {
   return new Response(e.message || e.toString(), { status: 500 });

--- a/lib/utils/exec/exec.utils.js
+++ b/lib/utils/exec/exec.utils.js
@@ -32,7 +32,8 @@ async function exec(command, scope = 'Process', verbose = false) {
       });
 
       buildProcess.stderr.on('data', (data) => {
-        // Some tools and libraries choose to use stderr for process logging or informational messages.
+        // Some tools and libraries choose to use
+        // stderr for process logging or informational messages.
         const dataStr = data.toString();
         if (dataStr.toLowerCase().includes('error')) {
           stream.error(dataStr);

--- a/lib/utils/feedback/feedback.utils.js
+++ b/lib/utils/feedback/feedback.utils.js
@@ -60,7 +60,7 @@ const scopes = {
   prebuild: { ...global.scope('Vulcan', 'Pre Build'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Pre Build'], types: methods }) },
   build: { ...global.scope('Vulcan', 'Build'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Build'], types: methods }) },
   platform: { ...global.scope('Vulcan', 'Platform'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Plataform'], types: methods }) },
-  statics: { ...global.scope('Vulcan', 'Statics'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Statics'], types: methods }) },
+  statics: { ...global.scope('Vulcan', 'storage'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'storage'], types: methods }) },
   propagation: { ...global.scope('Azion', 'Edge Network'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Azion Network'], types: methods }) },
 };
 /**

--- a/lib/utils/feedback/feedback.utils.js
+++ b/lib/utils/feedback/feedback.utils.js
@@ -62,7 +62,7 @@ const scopes = {
   runtime: { ...global.scope('Vulcan', 'Runtime'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Runtime'], types: methods }) },
   prebuild: { ...global.scope('Vulcan', 'Pre Build'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Pre Build'], types: methods }) },
   build: { ...global.scope('Vulcan', 'Build'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Build'], types: methods }) },
-  platform: { ...global.scope('Vulcan', 'Platform'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Plataform'], types: methods }) },
+  platform: { ...global.scope('Vulcan', 'Platform'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Platform'], types: methods }) },
   statics: { ...global.scope('Vulcan', 'Storage'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'storage'], types: methods }) },
   logs: (scope1, scope2, scope3) => ({ ...global.scope('Azion', `${scope1}`, scope2, scope3) }),
   propagation: { ...global.scope('Azion', 'Edge Network'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Azion Network'], types: methods }) },

--- a/lib/utils/feedback/feedback.utils.js
+++ b/lib/utils/feedback/feedback.utils.js
@@ -57,10 +57,12 @@ if (cleanOutputEnabled) {
  */
 const scopes = {
   ...global,
+  interactive: { ...getLogger({ interactive: true, scope: ['Vulcan'], types: methods }) },
   prebuild: { ...global.scope('Vulcan', 'Pre Build'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Pre Build'], types: methods }) },
   build: { ...global.scope('Vulcan', 'Build'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Build'], types: methods }) },
   platform: { ...global.scope('Vulcan', 'Platform'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Plataform'], types: methods }) },
-  statics: { ...global.scope('Vulcan', 'storage'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'storage'], types: methods }) },
+  statics: { ...global.scope('Vulcan', 'Storage'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'storage'], types: methods }) },
+  logs: (scope1, scope2, scope3) => ({ ...global.scope('Azion', `${scope1}`, scope2, scope3) }),
   propagation: { ...global.scope('Azion', 'Edge Network'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Azion Network'], types: methods }) },
 };
 /**

--- a/lib/utils/feedback/feedback.utils.js
+++ b/lib/utils/feedback/feedback.utils.js
@@ -58,6 +58,8 @@ if (cleanOutputEnabled) {
 const scopes = {
   ...global,
   interactive: { ...getLogger({ interactive: true, scope: ['Vulcan'], types: methods }) },
+  server: { ...global.scope('Vulcan', 'Server'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Server'], types: methods }) },
+  runtime: { ...global.scope('Vulcan', 'Runtime'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Runtime'], types: methods }) },
   prebuild: { ...global.scope('Vulcan', 'Pre Build'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Pre Build'], types: methods }) },
   build: { ...global.scope('Vulcan', 'Build'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Build'], types: methods }) },
   platform: { ...global.scope('Vulcan', 'Platform'), interactive: getLogger({ interactive: true, scope: ['Vulcan', 'Plataform'], types: methods }) },

--- a/lib/utils/overrideStaticOutputPath/overrideStaticOutputPath.utils.js
+++ b/lib/utils/overrideStaticOutputPath/overrideStaticOutputPath.utils.js
@@ -12,13 +12,13 @@ import { readFileSync, writeFileSync } from 'fs';
  * The regex pattern should include a capturing group (i.e., (.*) )
  * to identify the value to be replaced.
  * For example, /out:(.*)\n/.
- * @param {string} [newOutputPath='.edge/statics'] - The default is '.edge/statics'.
+ * @param {string} [newOutputPath='.edge/storage'] - The default is '.edge/storage'.
  * @throws Will throw an error if the function fails to override the output path.
  * @example
  *
  * overrideStaticOutputPath('./config.js', /out:(.*)\n/);
  */
-function overrideStaticOutputPath(configFilePath, regexPattern, newOutputPath = '.edge/statics') {
+function overrideStaticOutputPath(configFilePath, regexPattern, newOutputPath = '.edge/storage') {
   try {
     const fileContent = readFileSync(configFilePath, 'utf-8');
 


### PR DESCRIPTION
This pull request introduces changes related to the local environment. I started this PR by creating a server and a custom runtime to see how things went. In the last commit I made a refactor to use @edge-runtine (open source project) to maintain updates and the WinterCG standard. The changes include updates to:

-  'statics' concept renamed to 'storage'
- improved real-time log feedback
- enabling run/logs(function) commands without DEBUG=true
- adding 'Next preset' scope for improved feedback in Next.js prebuild
- Adding server/runtime feedback scopes
- adding Web APIS to the Runtime sandbox
- fetch method override for local files
- start waitUntilPromises interface
- implementing the '**debugRequest(event)'** edge hook to provide a ready-to-use interface for viewing the request both locally and on the edge

Additionally, there are refactorings and fixes related to the build, logs, feedback, edge hooks, and runtime modules.


