### PR TITLE
Docs: Improve jsdocs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 examples/*
+jsdoc/*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
           ["#build", "./lib/build/dispatcher/index.js"],
           ["#bundlers", "./lib/build/bundlers/index.js"],
           ["#notations/*", "./lib/notations"],
+          ["#namespaces", "./lib/notations/namespaces.js"],
           ["#env", "./lib/env/index.js"],
           ["#platform", "./lib/platform/index.js"],
           ["#constants", "./lib/constants/index.js"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
           ["#bundlers", "./lib/build/bundlers/index.js"],
           ["#notations/*", "./lib/notations"],
           ["#namespaces", "./lib/notations/namespaces.js"],
+          ["#typedef", "./lib/notations/typedef.js"],
           ["#env", "./lib/env/index.js"],
           ["#platform", "./lib/platform/index.js"],
           ["#constants", "./lib/constants/index.js"],

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 examples/*
+jsdoc/*
 yarn.lock
 CHANGELOG.md

--- a/aliases.js
+++ b/aliases.js
@@ -7,6 +7,7 @@ export default [
   ['#bundlers', './lib/build/bundlers/index.js'],
   ['#notations/*', './lib/notations'],
   ['#namespaces', './lib/notations/namespaces.js'],
+  ['#typedef', './lib/notations/typedef.js'],
   ['#env', './lib/env/index.js'],
   ['#platform', './lib/platform/index.js'],
   ['#constants', './lib/constants/index.js'],

--- a/aliases.js
+++ b/aliases.js
@@ -6,6 +6,7 @@ export default [
   ['#build', './lib/build/dispatcher/index.js'],
   ['#bundlers', './lib/build/bundlers/index.js'],
   ['#notations/*', './lib/notations'],
+  ['#namespaces', './lib/notations/namespaces.js'],
   ['#env', './lib/env/index.js'],
   ['#platform', './lib/platform/index.js'],
   ['#constants', './lib/constants/index.js'],

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -9,6 +9,7 @@
       "#build": ["./lib/build/dispatcher/index.js"],
       "#bundlers": ["./lib/build/bundlers/index.js"],
       "#notations/*": ["./lib/notations"],
+      "#namespaces": ["./lib/notations/namespaces.js"],
       "#env": ["./lib/env/index.js"],
       "#platform": ["./lib/platform/index.js"],
       "#constants": ["./lib/constants/index.js"],

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -10,6 +10,7 @@
       "#bundlers": ["./lib/build/bundlers/index.js"],
       "#notations/*": ["./lib/notations"],
       "#namespaces": ["./lib/notations/namespaces.js"],
+      "#typedef": ["./lib/notations/typedef.js"],
       "#env": ["./lib/env/index.js"],
       "#platform": ["./lib/platform/index.js"],
       "#constants": ["./lib/constants/index.js"],

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -30,14 +30,14 @@
       "menu": [
         {
           "title": "Github",
-          "link": "https://github.com/@aziontech/vulcan/",
+          "link": "https://github.com/aziontech/vulcan/",
           "target": "_blank",
           "class": "some-class",
           "id": "some-id"
         },
         {
           "title": "Azion",
-          "link": "https:/azion.com",
+          "link": "https://azion.com",
           "target": "_blank",
           "class": "some-class",
           "id": "some-id"

--- a/lib/build/bundlers/esbuild/plugins/node-polyfills/index.js
+++ b/lib/build/bundlers/esbuild/plugins/node-polyfills/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Based on https://github.com/remorses/esbuild-plugins/blob/master/node-modules-polyfill/src/index.ts
 
 import escapeStringRegexp from 'escape-string-regexp';
@@ -65,10 +66,8 @@ export function NodeModulesPolyfillPlugin(options = {}) {
     setup: function setup({ onLoad, onResolve, initialOptions }) {
       // polyfills contain global keyword, it must be defined
       if (initialOptions?.define && !initialOptions.define?.global) {
-        // eslint-disable-next-line
         initialOptions.define.global = 'globalThis';
       } else if (!initialOptions?.define) {
-        // eslint-disable-next-line
         initialOptions.define = { global: 'globalThis' };
       }
 
@@ -120,10 +119,7 @@ export function NodeModulesPolyfillPlugin(options = {}) {
           .map(escapeStringRegexp)
           .join('|'), // TODO builtins could end with slash, keep in mind in regex
       );
-      /**
-       *
-       * @param args
-       */
+
       async function resolver(args) {
         const argsPath = args.path.replace(/^node:/, '');
         const ignoreRequire = args.namespace === commonjsNamespace;
@@ -134,7 +130,6 @@ export function NodeModulesPolyfillPlugin(options = {}) {
 
         const isCommonjs = !ignoreRequire && args.kind === 'require-call';
 
-        // eslint-disable-next-line
         return {
           namespace: isCommonjs ? commonjsNamespace : namespace,
           path: argsPath,
@@ -147,3 +142,4 @@ export function NodeModulesPolyfillPlugin(options = {}) {
 }
 
 export default NodeModulesPolyfillPlugin;
+/* eslint-enable */

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -159,10 +159,6 @@ async function loadBuildContext(preset, entry, mode) {
 /**
 Create a .env file in the build folder with specified parameters.
  * @param {string} buildId - The version ID to write into the .env file.
- * @param {string} entry - Entrypoint path.
- * @param {string} preset - The preset to write into the .env file.
- * @param {string} mode - The mode to write into the .env file.
- * @param {boolean} useNodePolyfills - The flag to indicates polyfills use.
  */
 function createDotEnvFile(buildId) {
   const projectRoot = process.cwd();
@@ -180,7 +176,7 @@ function createDotEnvFile(buildId) {
 /**
  * Check folder exists in project
  * @param {string} folder - Folder e.g node_modules
- * @returns {Promise<boolean>}
+ * @returns {Promise<boolean>} - a promise if dir exists or not
  */
 async function folderExistsInProject(folder) {
   const filePath = join(process.cwd(), folder);

--- a/lib/build/polyfills/node/http2.js
+++ b/lib/build/polyfills/node/http2.js
@@ -2,8 +2,8 @@
 // Copyright Joyent and Node contributors. All rights reserved. MIT license.
 
 /**
- *
- * @param name
+ * Function that throws unimplemented error
+ * @param {string} name - the class name
  */
 function unimplemented(name) {
   throw new Error(`Node.js HTTP/2 ${name} is not currently supported`);
@@ -14,77 +14,95 @@ class Http2Session {
     unimplemented(this.constructor.name);
   }
 }
+
 class ServerHttp2Session {
   constructor() {
     unimplemented(this.constructor.name);
   }
 }
+
 class ClientHttp2Session {
   constructor() {
     unimplemented(this.constructor.name);
   }
 }
+
 class Http2Stream {
   constructor() {
     unimplemented(this.constructor.name);
   }
 }
+
 class ClientHttp2Stream {
   constructor() {
     unimplemented(this.constructor.name);
   }
 }
+
 class ServerHttp2Stream {
   constructor() {
     unimplemented(this.constructor.name);
   }
 }
+
 class Http2Server {
   constructor() {
     unimplemented(this.constructor.name);
   }
 }
+
 class Http2SecureServer {
   constructor() {
     unimplemented(this.constructor.name);
   }
 }
-/**
- *
- */
-function createServer() {}
-/**
- *
- */
-function createSecureServer() {}
-/**
- *
- */
-function connect() {}
-const constants = {};
-/**
- *
- */
-function getDefaultSettings() {}
-/**
- *
- */
-function getPackedSettings() {}
-/**
- *
- */
-function getUnpackedSettings() {}
-const sensitiveHeaders = Symbol('nodejs.http2.sensitiveHeaders');
+
 class Http2ServerRequest {
   constructor() {
     unimplemented(this.constructor.name);
   }
 }
+
 class Http2ServerResponse {
   constructor() {
     unimplemented(this.constructor.name);
   }
 }
+
+/**
+ * mock function to be used in build bypass
+ */
+function createServer() {}
+
+/**
+ * mock function to be used in build bypass
+ */
+function createSecureServer() {}
+
+/**
+ * mock function to be used in build bypass
+ */
+function connect() {}
+
+/**
+ * mock function to be used in build bypass
+ */
+function getDefaultSettings() {}
+
+/**
+ * mock function to be used in build bypass
+ */
+function getPackedSettings() {}
+
+/**
+ * mock function to be used in build bypass
+ */
+function getUnpackedSettings() {}
+
+const sensitiveHeaders = Symbol('nodejs.http2.sensitiveHeaders');
+
+const constants = {};
+
 const http2 = {
   Http2Session,
   ServerHttp2Session,

--- a/lib/commands/auth.commands.js
+++ b/lib/commands/auth.commands.js
@@ -1,9 +1,12 @@
 import { createPromptModule } from 'inquirer';
 
+import { Commands } from '#namespaces';
+
 const prompt = createPromptModule();
 /**
- * A command to handle authentication through various methods.
- * @memberof commands
+ * @function
+ * @memberof Commands
+ * @description A command to handle authentication through various methods.
  * @param {object} options - Configuration options for authentication
  * @param {string} [options.password] - Credentials in the format "username:password"
  * @param {string} [options.token] - Personal authentication token

--- a/lib/commands/build.commands.js
+++ b/lib/commands/build.commands.js
@@ -1,8 +1,11 @@
 import { feedback } from '#utils';
 
+import { Commands } from '#namespaces';
+
 /**
- * A command to initiate the build process.
- * @memberof commands
+ * @function
+ * @memberof Commands
+ * @description A command to initiate the build process.
  * @param {object} options - Configuration options for the build command
  * @param {string} options.entry - The entry point file for the build
  * @param {string} options.preset - Preset to be used (e.g., 'javascript', 'typescript')

--- a/lib/commands/deploy.commands.js
+++ b/lib/commands/deploy.commands.js
@@ -1,10 +1,13 @@
 import { join } from 'path';
 import { createPromptModule } from 'inquirer';
 
+import { Commands } from '#namespaces';
+
 const prompt = createPromptModule();
 /**
- * A Command to deploy a web application.
- * @memberof commands
+ * @function
+ * @memberof Commands
+ * @description A Command to deploy a web application.
  * This command will ask for the application name and function name via the terminal.
  * Then, it will upload static files and deploy the application.
  * Finally, it watches for the propagation of the deployment.

--- a/lib/commands/dev.commands.js
+++ b/lib/commands/dev.commands.js
@@ -1,9 +1,11 @@
 import { join } from 'path';
 
+import { Commands } from '#namespaces';
+
 /**
- * A command to start the development server.
- * @memberof commands
- *
+ * @function
+ * @memberof Commands
+ * @description A command to start the development server.
  * This function takes a file path and options object as arguments.
  * The file path is the entry point for the development server,
  * and the options object contains the port number.

--- a/lib/commands/init.commands.js
+++ b/lib/commands/init.commands.js
@@ -5,10 +5,14 @@ import { FrameworkInitializer, Messages } from '#constants';
 import { feedback, debug } from '#utils';
 import { vulcan } from '#env';
 
+import { Commands } from '#namespaces';
+
 const prompt = createPromptModule();
 
 /**
- * Initializes a new project based on the selected framework template.
+ * @function
+ * @memberof Commands
+ * @description Initializes a new project based on the selected framework template.
  * @param {object} options - Configuration options for initialization.
  * @param {string} options.name - Name of the new project.
  * If not provided, the function will prompt for it.

--- a/lib/commands/logs.commands.js
+++ b/lib/commands/logs.commands.js
@@ -1,8 +1,11 @@
 import { feedback } from '#utils';
 import { Messages } from '#constants';
+import { Commands } from '#namespaces';
+
 /**
- * A comamnd to display logs for a specified function or application.
- * @memberof commands
+ * @function
+ * @memberof Commands
+ * @description A comamnd to display logs for a specified function or application.
  * This function allows the user to view logs for a specific function or application.
  * Note that viewing logs for applications is currently unsupported.
  * @param {string} type - The type of entity to show logs for.

--- a/lib/commands/presets.commands.js
+++ b/lib/commands/presets.commands.js
@@ -1,12 +1,15 @@
 import { createPromptModule } from 'inquirer';
+
 import { Messages } from '#constants';
 import { feedback, debug } from '#utils';
+import { Commands } from '#namespaces';
 
 const prompt = createPromptModule();
 
 /**
- * Manages presets for the application.
- * @memberof commands
+ * @function
+ * @memberof Commands
+ * @description Manages presets for the application.
  * This command allows the user to create or list presets and modes.
  * The user is guided by a series of prompts to enter a preset name and mode.
  * @param {string} command - The operation to be performed:

--- a/lib/commands/storage.commands.js
+++ b/lib/commands/storage.commands.js
@@ -1,8 +1,11 @@
 import { join } from 'path';
 
+import { Commands } from '#namespaces';
+
 /**
- * A command to uploads static files for a given version of the application.
- * @memberof commands
+ * @function
+ * @memberof Commands
+ * @description A command to uploads static files for a given version of the application.
  * The function identifies the build version, prepares a base path for static files,
  * and uploads these files to the storage of the core platform.
  * @returns {Promise<void>} - A promise that resolves when static files are successfully uploaded.

--- a/lib/notations/namespaces.js
+++ b/lib/notations/namespaces.js
@@ -1,35 +1,67 @@
+/* eslint-disable no-unused-vars */
 /**
- * @namespace utils
+ * @namespace Utils
  * @description Provides utility functions for various tasks.
  */
+const Utils = {};
 
 /**
- * @namespace platform
+ * @namespace Platform
  * @description Contains functions and actions to interact with the edge platform (Azion).
  */
+const Platform = {};
 
 /**
- * @namespace build
+ * @namespace Build
  * @description Represents the structure responsible for pre-build and build processes for the edge.
  */
+const Build = {};
 
 /**
- * @namespace env
+ * @namespace Env
  * @description Contains codes and functions responsible for managing the local environment.
  */
+const Env = {};
 
 /**
- * @namespace presets
+ * @namespace Presets
  * @description Contains presets with pre-configured workers and
  *  Presets available to run on the edge.
  */
+const Presets = {};
 
 /**
- * @namespace edge
+ * @namespace Edge
  * @description Contains imported and computer-ready functions for use on the edge.
  */
+const Edge = {};
 
 /**
- * @namespace polyfills
+ * @namespace Commands
+ * @description Contains vulcan commands.
+ */
+const Commands = {};
+
+/**
+ * @namespace Polyfills
  * @description Contains polyfills that are used in the local environment and in build.
  */
+const Polyfills = {};
+
+/**
+ * @namespace Services
+ * @description Azion Platform Services.
+ */
+const Services = {};
+
+export {
+  Utils,
+  Platform,
+  Build,
+  Env,
+  Presets,
+  Edge,
+  Polyfills,
+  Commands,
+  Services,
+};

--- a/lib/notations/typedef.js
+++ b/lib/notations/typedef.js
@@ -1,10 +1,32 @@
 /**
+ * Represents an event object received by a Azion Cells.
  * @typedef {object} FetchEvent
- * @property {Request} request - This interface represents a resource request.
- * @property {Promise<Response>} respondWith - This interface prevents the browser's
- * default fetch handling,  and allows you to provide a promise for a Response yourself.
- * @property {function(): void} waitUntil  - his interface is used to inform the browser
- * not to terminate the Service Worker until
- * the promise passed to `waitUntil` is either resolved or rejected.
- * @description Represents an event that is dispatched to a worker when a fetch event occurs.
+ * @property {Request} request - The incoming HTTP request.
+ * @property {Response} response - The HTTP response object.
+ * @property {string} type - The type of event (e.g., 'fetch', 'scheduled', etc.).
+ * @property {EventOptions} options - Options for handling the event.
+ */
+
+/**
+ * Represents an HTTP request.
+ * @typedef {object} Request
+ * @property {string} method - The HTTP method (e.g., 'GET', 'POST').`
+ * @property {Headers} headers - HTTP headers of the request.
+ * @property {string} url - The URL of the request.
+ * @property {object} body - The body of the request (parsed based on content type).
+ */
+
+/**
+ * Represents an HTTP response.
+ * @typedef {object} Response
+ * @property {number} status - The HTTP status code (e.g., 200, 404).
+ * @property {Headers} headers - HTTP headers of the response.
+ * @property {string|ReadableStream|ArrayBuffer|FormData|Blob} body - The response body.
+ */
+
+/**
+ * Represents options for handling a Azion Cells event.
+ * @typedef {object} EventOptions
+ * @property {boolean} passThroughOnException - Whether to pass the event through when an exception occurs.
+ * @property {string} waitUntil - A promise that can be used to wait for asynchronous operations to complete.
  */

--- a/lib/platform/actions/application/createApplication.actions.js
+++ b/lib/platform/actions/application/createApplication.actions.js
@@ -1,9 +1,10 @@
 import { debug } from '#utils';
+import { Platform } from '#namespaces';
 import ApplicationService from '../../services/application.service.js';
+
 /**
  * @function
- * @memberof platform
- * @name createApplication
+ * @memberof Platform
  * @description Creates a new application using the specified application name.
  * @param {string} applicationName - The name of the new application.
  * @returns {Promise<object>} A promise that resolves to the newly created application object.

--- a/lib/platform/actions/application/enableEdgeFunctions.actions.js
+++ b/lib/platform/actions/application/enableEdgeFunctions.actions.js
@@ -1,9 +1,10 @@
 import { debug } from '#utils';
+import { Platform } from '#namespaces';
 import ApplicationService from '../../services/application.service.js';
+
 /**
  * @function
- * @memberof platform
- * @name enableEdgeFunctions
+ * @memberof Platform
  * @description Enables edge functions for the specified application.
  * @param {number} applicationId - The unique identifier of the application.
  * @returns {Promise<object>} A promise that resolves to the updated application

--- a/lib/platform/actions/application/instantiateFunction.actions.js
+++ b/lib/platform/actions/application/instantiateFunction.actions.js
@@ -1,10 +1,10 @@
 import { debug } from '#utils';
+import { Platform } from '#namespaces';
 import ApplicationService from '../../services/application.service.js';
 
 /**
  * @function
- * @memberof platform
- * @name instantiateFunction
+ * @memberof Platform
  * @description Instantiates an edge function in the specified application.
  * @param {string} functionName - The name of the function to be instantiated.
  * @param {number} functionId - The unique identifier of the function to be instantiated.

--- a/lib/platform/actions/application/setFunctionAsDefaultRule.actions.js
+++ b/lib/platform/actions/application/setFunctionAsDefaultRule.actions.js
@@ -1,7 +1,11 @@
 import { debug } from '#utils';
+import { Platform } from '#namespaces';
 import ApplicationService from '../../services/application.service.js';
+
 /**
- * Sets a function as the default rule in an application's rules engine.
+ * @function
+ * @memberof Platform
+ * @description Sets a function as the default rule in an application's rules engine.
  * @param {number} applicationId - The ID of the application.
  * @param {number} functionInstanceId - The ID of the edge function instance.
  * @returns {Promise<object>} The updated rules engine rules.

--- a/lib/platform/actions/core/auth.actions.js
+++ b/lib/platform/actions/core/auth.actions.js
@@ -1,13 +1,13 @@
 import { vulcan } from '#env';
 import { Messages } from '#constants';
 import { feedback, debug } from '#utils';
+import { Platform } from '#namespaces';
 import TokensService from '../../services/tokens.service.js';
 import FunctionService from '../../services/function.service.js';
 
 /**
  * @function
- * @memberof platform
- * @name auth
+ * @memberof Platform
  * @description Authenticates the user with the provided credentials.
  * @param {string} loginOption - The chosen login method. Valid values are
  * 'username/password' and 'token'.

--- a/lib/platform/actions/core/deploy.actions.js
+++ b/lib/platform/actions/core/deploy.actions.js
@@ -1,8 +1,7 @@
 import { feedback, generateTimestamp, debug } from '#utils';
 import { Messages } from '#constants';
-
+import { Platform } from '#namespaces';
 import createApplication from '../application/createApplication.actions.js';
-
 import instantiateFunction from '../application/instantiateFunction.actions.js';
 import enableEdgeFunctions from '../application/enableEdgeFunctions.actions.js';
 import setFunctionAsDefaultRule from '../application/setFunctionAsDefaultRule.actions.js';
@@ -11,8 +10,7 @@ import createFunction from '../function/createFunction.actions.js';
 
 /**
  * @function
- * @memberof platform
- * @name deploy
+ * @memberof Platform
  * @description Creates a new application from scratch, performing several steps including
  * function creation, application creation, enabling edge functions, function instantiation,
  * rule setting, and domain creation. If names are not provided, they will be auto-generated

--- a/lib/platform/actions/core/propagation.actions.js
+++ b/lib/platform/actions/core/propagation.actions.js
@@ -1,12 +1,12 @@
 import { AzionEdges, Messages } from '#constants';
 import { feedback, debug, exec } from '#utils';
+import { Platform } from '#namespaces';
 
 const isWindows = process.platform === 'win32';
 
 /**
  * @function
- * @memberof platform
- * @name watchPropagation
+ * @memberof Platform
  * @description Monitors the propagation of a domain across the edge networks after the FIRST
  * deployment. This function fetches the specified domain at regular intervals to check for
  *  propagation status. It interprets a 404 response as indicating that the domain is still

--- a/lib/platform/actions/core/storage.actions.js
+++ b/lib/platform/actions/core/storage.actions.js
@@ -2,14 +2,15 @@ import fs from 'fs';
 import path from 'path';
 import mime from 'mime-types';
 import { promisify } from 'util';
+
 import { feedback, debug } from '#utils';
 import { Messages } from '#constants';
+import { Platform } from '#namespaces';
 import StorageService from '../../services/storage.service.js';
 
 /**
  * @function
- * @memberof platform
- * @name uploadStatics
+ * @memberof Platform
  * @description Uploads files to the storage. This function recursively navigates
  * through the directory structure from the specified base path and uploads all the files
  * it encounters. It counts the successful uploads and provides feedback on each file upload status.

--- a/lib/platform/actions/domain/createDomain.actions.js
+++ b/lib/platform/actions/domain/createDomain.actions.js
@@ -1,10 +1,10 @@
 import { debug } from '#utils';
+import { Platform } from '#namespaces';
 import DomainService from '../../services/domain.service.js';
 
 /**
  * @function
- * @memberof platform
- * @name createDomain
+ * @memberof Platform
  * @description Creates a new domain for a specific application. This operation requires
  * both the name for the new domain and the ID of the application to which it will be linked.
  * @param {string} domainName - The name of the domain to be created.

--- a/lib/platform/actions/function/createFunction.actions.js
+++ b/lib/platform/actions/function/createFunction.actions.js
@@ -1,9 +1,13 @@
 import fs from 'fs';
 import path from 'path';
+
 import { debug } from '#utils';
+import { Platform } from '#namespaces';
 import FunctionService from '../../services/function.service.js';
 
 /**
+ * @function
+ * @memberof Platform
  * Get the initiator type based on the code signature.
  * @param {string} code - The code for the function.
  * @returns {string} The initiator type.
@@ -23,8 +27,7 @@ function getInitiatorType(code) {
 
 /**
  * @function
- * @memberof platform
- * @name createFunction
+ * @memberof Platform
  * @description Creates a new function (worker) for the edge application.
  * It reads the function code and arguments from the respective '.edge/worker.js'
  * and '.edge/args.json' files, and infers the initiator type based on the function's code.

--- a/lib/platform/actions/function/showFunctionLogs.actions.js
+++ b/lib/platform/actions/function/showFunctionLogs.actions.js
@@ -1,10 +1,13 @@
 import { feedback, debug } from '#utils';
 import { Messages } from '#constants';
+import { Platform } from '#namespaces';
 import eventsService from '../../services/events.service.js';
 
 /**
- *
- * @param {object} log - View logs organized in a box.
+ * @function
+ * @memberof Platform
+ * @description View logs organized in a box.
+ * @param {object} log - the log to display
  */
 function displayLogInBox(log) {
   log.logLines.forEach((line) => {
@@ -30,8 +33,7 @@ function displayLogInBox(log) {
 
 /**
  * @function
- * @memberof platform
- * @name showFunctionLogs
+ * @memberof Platform
  * @description This function retrieves and displays the logs of a specific function
  * or all functions from the edge application. If the watch parameter is set to true,
  * it continuously polls and updates the function logs in real time.
@@ -55,7 +57,9 @@ async function showFunctionLogs(functionId, watch = false) {
   let logsToDisplay = {};
 
   /**
-   * Mounts the structure for a console log.
+   * @function
+   * @memberof Platform
+   * @description Mounts the structure for a console log.
    * @param {object} azionLog - The Azion log event.
    * @param {string} azionLog.id - The ID of the event.
    * @param {string} azionLog.ts - The timestamp of the event.

--- a/lib/platform/edgehooks/ErrorHTML/ErrorHTML.hooks.js
+++ b/lib/platform/edgehooks/ErrorHTML/ErrorHTML.hooks.js
@@ -1,5 +1,8 @@
+import { Edge } from '#namespaces';
+
 /**
- * @function formatLog
+ * @function
+ * @memberof Edge
  * @description Formats the request and error information for logging.
  * @param {Error} error - The error object.
  * @returns {string} The formatted log string.
@@ -16,7 +19,8 @@ function formatLog(error) {
 }
 
 /**
- * @function createErrorHTML
+ * @function
+ * @memberof Edge
  * @description Creates the HTML content for the custom error page.
  * @param {number} errorCode - The error code.
  * @param {string} errorDescription - The error description.
@@ -82,8 +86,7 @@ function createErrorHTML(errorCode, errorDescription, error) {
 
 /**
  * @function
- * @memberof edge
- * @name ErrorHTML
+ * @memberof Edge
  * @description Handles an error by logging the request and error
  * information and returning a custom HTML response.
  * @param {number} code - The error code.

--- a/lib/platform/edgehooks/debugRequest/debugRequest.hooks.js
+++ b/lib/platform/edgehooks/debugRequest/debugRequest.hooks.js
@@ -1,9 +1,9 @@
+import { Edge } from '#namespaces';
+
 /**
  * @function
- * @name DebugRequest
- * @memberof edge
- * @description
- * The `DebugRequest` function is used to debug and display the details of an incoming request.
+ * @memberof Edge
+ * @description The `DebugRequest` function is used to debug and display the details of an incoming request.
  * It takes the request as a parameter and logs the request URL, method, and headers to the console.
  * @param {FetchEvent} event - The incoming FetchEvent object.
  * @returns {Promise<void>} A promise that resolves once the request details are logged.

--- a/lib/platform/edgehooks/debugRequest/debugRequest.hooks.js
+++ b/lib/platform/edgehooks/debugRequest/debugRequest.hooks.js
@@ -1,4 +1,5 @@
 import { Edge } from '#namespaces';
+import { FetchEvent } from '#typedef';
 
 /**
  * @function

--- a/lib/platform/edgehooks/mountSPA/mountSPA.hooks.js
+++ b/lib/platform/edgehooks/mountSPA/mountSPA.hooks.js
@@ -1,9 +1,9 @@
+import { Edge } from '#namespaces';
+
 /**
- * @memberof edge
  * @function
- * @name mountSPA
- * @description
- * The `mountSPA` function is designed to process requests to a Single Page Application (SPA)
+ * @memberof Edge
+ * @description The `mountSPA` function is designed to process requests to a Single Page Application (SPA)
  * that's being computed at the edge of a Content Delivery Network (CDN).
  *
  * This function determines if the incoming request is for a static
@@ -25,7 +25,7 @@
  * // Input: mountSSG('https://example.com/about', 'v1');
  * // Output: fetch('file:///v1/index.html');
  */
-export default function mountSPA(requestURL, versionId) {
+function mountSPA(requestURL, versionId) {
   /**
    * The path extracted from the request URL.
    * @type {string}
@@ -53,3 +53,5 @@ export default function mountSPA(requestURL, versionId) {
 
   return fetch(assetPath);
 }
+
+export default mountSPA;

--- a/lib/platform/edgehooks/mountSSG/mountSSG.hooks.js
+++ b/lib/platform/edgehooks/mountSSG/mountSSG.hooks.js
@@ -1,9 +1,9 @@
+import { Edge } from '#namespaces';
+
 /**
- * @memberof edge
- * @function mountSSG
- * @name mountSSG
- *@description
- * The `mountSSG` function is designed to handle requests for Static Site Generation (SSG)
+ * @function
+ * @memberof Edge
+ * @description The `mountSSG` function is designed to handle requests for Static Site Generation (SSG)
  * at the edge, that is, directly within a serverless worker.
  * It processes the incoming request URL and an associated version ID. The function constructs
  * the appropriate asset path based on these parameters, and fetches the corresponding
@@ -24,7 +24,7 @@
  * // Input: mountSSG('https://example.com/about', 'v1');
  * // Output: fetch('file:///v1/about/index.html');
  */
-export default function mountSSG(requestURL, versionId) {
+function mountSSG(requestURL, versionId) {
   /**
    * The path extracted from the request URL.
    * @type {string}
@@ -64,3 +64,5 @@ export default function mountSSG(requestURL, versionId) {
 
   return fetch(assetPath);
 }
+
+export default mountSSG;

--- a/lib/platform/services/application.service.js
+++ b/lib/platform/services/application.service.js
@@ -1,3 +1,4 @@
+import { Services } from '#namespaces';
 import BaseService from './base.service.js';
 
 /**

--- a/lib/platform/services/base.service.js
+++ b/lib/platform/services/base.service.js
@@ -1,3 +1,4 @@
+import { Services } from '#namespaces';
 import { vulcan } from '#env';
 import _ from 'lodash';
 
@@ -40,7 +41,7 @@ const getAuthHeaders = async () => {
  * In addition to standard GET, POST, PUT, PATCH, and DELETE requests,
  *  BaseService also supports GraphQL queries
  * BaseService includes methods for GET, POST, PUT, PATCH, DELETE, and GraphQL requests.
- * @namespace Services
+ * @memberof Services
  * @class BaseService
  * @type {BaseService}
  * @example

--- a/lib/platform/services/domain.service.js
+++ b/lib/platform/services/domain.service.js
@@ -1,3 +1,4 @@
+import { Services } from '#namespaces';
 import BaseService from './base.service.js';
 
 /**

--- a/lib/platform/services/events.service.js
+++ b/lib/platform/services/events.service.js
@@ -1,3 +1,4 @@
+import { Services } from '#namespaces';
 import BaseService from './base.service.js';
 
 /**

--- a/lib/platform/services/function.service.js
+++ b/lib/platform/services/function.service.js
@@ -1,3 +1,4 @@
+import { Services } from '#namespaces';
 import BaseService from './base.service.js';
 
 /**

--- a/lib/platform/services/storage.service.js
+++ b/lib/platform/services/storage.service.js
@@ -1,3 +1,4 @@
+import { Services } from '#namespaces';
 import BaseService from './base.service.js';
 
 /**

--- a/lib/platform/services/tokens.service.js
+++ b/lib/platform/services/tokens.service.js
@@ -1,3 +1,4 @@
+import { Services } from '#namespaces';
 import BaseService from './base.service.js';
 
 /**

--- a/lib/presets/custom/angular/deliver/handler.js
+++ b/lib/presets/custom/angular/deliver/handler.js
@@ -1,4 +1,5 @@
 import { mountSPA, ErrorHTML } from '#edge';
+import { FetchEvent } from '#typedef';
 
 /**
  * Handles the 'fetch' event.

--- a/lib/presets/custom/astro/deliver/handler.js
+++ b/lib/presets/custom/astro/deliver/handler.js
@@ -1,4 +1,5 @@
 import { mountSSG, ErrorHTML } from '#edge';
+import { FetchEvent } from '#typedef';
 
 /**
  * Handles the 'fetch' event.

--- a/lib/presets/custom/hexo/deliver/handler.js
+++ b/lib/presets/custom/hexo/deliver/handler.js
@@ -1,4 +1,5 @@
 import { mountSSG, ErrorHTML } from '#edge';
+import { FetchEvent } from '#typedef';
 
 /**
  * Handles the 'fetch' event.

--- a/lib/presets/custom/next/compute/handler.js
+++ b/lib/presets/custom/next/compute/handler.js
@@ -1,3 +1,5 @@
+import { FetchEvent } from '#typedef';
+
 /* eslint-disable import/no-unresolved */
 // .edge files are dynamically generated
 import { assets } from './.edge/next-build/statics.js';

--- a/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/compute-js.js
+++ b/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/compute-js.js
@@ -6,9 +6,10 @@
  */
 
 /**
- *
- * @param backends
- * @param url
+ * Find backend infos (name, url, target) in backends
+ * @param {Record<string, string | object>} backends backend infos
+ * @param {string} url the application url
+ * @returns {object | null} backend infos (name, url, target)
  */
 function findBackendInfo(backends, url) {
   const entries = Object.entries(backends);
@@ -31,9 +32,10 @@ function findBackendInfo(backends, url) {
 }
 
 /**
- *
- * @param backends
- * @param url
+ * Return backend infos (name, url, target)
+ * @param {Record<string, string | object> | undefined} backends backend infos
+ * @param {string} url the application url
+ * @returns {object | null} backend infos (name, url, target)
  */
 export default function getBackendInfo(backends, url) {
   if (backends == null) {

--- a/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/config.js
+++ b/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/config.js
@@ -47,8 +47,9 @@ const experimentalWarning = execOnce((configFileName, features) => {
 });
 
 /**
- *
- * @param srcUserConfig
+ * Generate NextConfig with user + default configs
+ * @param {object} srcUserConfig user NextConfig
+ * @returns {object} the generated NextConfig
  */
 function assignDefaults(srcUserConfig) {
   const userConfig = { ...srcUserConfig };
@@ -715,10 +716,11 @@ function assignDefaults(srcUserConfig) {
  * Loads the appropriate NextConfig for the specified phase.
  * (An adaptation for Compute@Edge of function in Next.js of the same name,
  * found at next/server/config.ts)
- * @param phase
- * @param assets
- * @param dir
- * @param customConfig
+ * @param {string} phase the nextjs phase
+ * @param {object} assets object with assets infos
+ * @param {string} dir the reference dir
+ * @param {object|null} customConfig the custom NextConfig
+ * @returns {Promise<object>} a promise with the complete next config
  */
 export default async function loadConfig(phase, assets, dir, customConfig) {
   // no .env in Compute@Edge

--- a/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/load-components.js
+++ b/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/load-components.js
@@ -23,13 +23,14 @@ import { readAssetManifest, requirePage } from './require.js';
  * Loads React component associated with a given pathname.
  * (An adaptation for Compute@Edge of function in Next.js of the same name,
  * found at next/server/load-components.ts)
- * @param assets
- * @param distDir
- * @param pathname
- * @param dir
- * @param serverless
- * @param hasServerComponents
- * @param isAppPath
+ * @param {Record<string, object>} assets assets infos (contentType, content, module, isStatic)
+ * @param {string} distDir reference builded dir
+ * @param {string} pathname page path name
+ * @param {string} dir reference dir
+ * @param {boolean} serverless indicates serverless mode
+ * @param {boolean} hasServerComponents indicates that has server components
+ * @param {boolean} isAppPath indicates that is a app path
+ * @returns {Promise<object>} a promise with component infos
  */
 export default async function loadComponents(
   assets,

--- a/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/next-compute-js-server.js
+++ b/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/next-compute-js-server.js
@@ -497,6 +497,7 @@ export default class NextComputeJsServer extends BaseServer {
       proto,
     };
 
+    // eslint-disable-next-line func-names
     ['for', 'port', 'proto'].forEach(function (header) {
       const arr = [];
       let strs = req.headers[`x-forwarded-${header}`];
@@ -1097,10 +1098,11 @@ export default class NextComputeJsServer extends BaseServer {
 
   /**
    * Resolves `API` request, in development builds on demand
-   * @param req http request
-   * @param res http response
-   * @param pathname path of request
-   * @param query
+   * @param {object} req http request
+   * @param {object} res http response
+   * @param {string} pathname path of request
+   * @param {string} query request query
+   * @returns {Promise<boolean>} a promise indicating whether the page has been handled
    */
   async handleApiRequest(req, res, pathname, query) {
     let page = pathname;

--- a/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/next.js
+++ b/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/next.js
@@ -92,8 +92,9 @@ export class NextServer {
 }
 
 /**
- *
- * @param options
+ * Create and returns an Next Server
+ * @param {object} options next server options
+ * @returns {NextComputeJsServer} a next server instance
  */
 export default async function createServer(options) {
   const server = new NextServer(options);

--- a/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/require.js
+++ b/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/require.js
@@ -86,17 +86,17 @@ export function readAssetFile(assets, path, dir) {
  * @returns {Promise<Uint8Array>} the promise with the content
  */
 export async function readAsyncAssetFile(assets, path, dir) {
-  console.log('readAsyncAssetFile', path);
-  console.time('readAsyncAssetFile');
   const relativePath = relative(dir, path);
   const file = assets[`/${relativePath}`];
   const urlOBJ = new URL(`${file.content}`, 'file://');
   const response = await fetch(`${urlOBJ}`);
   if (!response.ok) {
+    console.log(
+      `Error reading asset '${path}' in storage. Error: ${response.status} - ${response.statusText}`,
+    );
     throw new Error('Error loading file.');
   }
   const buffer = await response.arrayBuffer();
-  console.timeEnd('readAsyncAssetFile');
   return Promise.resolve(new Uint8Array(buffer));
 }
 

--- a/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/require.js
+++ b/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/require.js
@@ -27,10 +27,11 @@ import {
 /* eslint-enable */
 
 /**
- *
- * @param assets
- * @param path
- * @param dir
+ * Check if asset dir exists
+ * @param {object} assets object with assets infos
+ * @param {string} path the asset path
+ * @param {string} dir the reference dir
+ * @returns {boolean} existence indicative
  */
 export function assetDirectoryExists(assets, path, dir) {
   const relativePath = relative(dir, path);
@@ -38,10 +39,11 @@ export function assetDirectoryExists(assets, path, dir) {
 }
 
 /**
- *
- * @param assets
- * @param path
- * @param dir
+ * Filter assets based on a path
+ * @param {object} assets object with assets infos
+ * @param {string} path the asset path
+ * @param {string} dir the reference dir
+ * @returns {string[]} the filtered results
  */
 export function assetDirectory(assets, path, dir) {
   const relativePath = relative(dir, path);
@@ -51,10 +53,11 @@ export function assetDirectory(assets, path, dir) {
 }
 
 /**
- *
- * @param assets
- * @param path
- * @param dir
+ * Check if asset file exists
+ * @param {object} assets object with assets infos
+ * @param  {string} path the asset path
+ * @param {string} dir the reference dir
+ * @returns {boolean} indication of asset existence
  */
 export function assetFileExists(assets, path, dir) {
   const relativePath = relative(dir, path);
@@ -62,10 +65,11 @@ export function assetFileExists(assets, path, dir) {
 }
 
 /**
- *
- * @param assets
- * @param path
- * @param dir
+ * Read asset file (injected content) based on a path
+ * @param {object} assets object with assets infos
+ * @param {string} path the asset path
+ * @param {string} dir the reference dir
+ * @returns {Buffer} the asset content
  */
 export function readAssetFile(assets, path, dir) {
   const relativePath = relative(dir, path);
@@ -75,10 +79,11 @@ export function readAssetFile(assets, path, dir) {
 }
 
 /**
- *
- * @param assets
- * @param path
- * @param dir
+ * Read asset file from storage using fetch
+ * @param {object} assets object with assets infos
+ * @param {string} path the asset path
+ * @param {string} dir the reference dir
+ * @returns {Promise<Uint8Array>} the promise with the content
  */
 export async function readAsyncAssetFile(assets, path, dir) {
   console.log('readAsyncAssetFile', path);
@@ -96,10 +101,11 @@ export async function readAsyncAssetFile(assets, path, dir) {
 }
 
 /**
- *
- * @param assets
- * @param path
- * @param dir
+ * Read asset file (injected content) as a string
+ * @param {object} assets object with assets infos
+ * @param {string} path the asset path
+ * @param {string} dir the reference dir
+ * @returns {string} the file content
  */
 export function readAssetFileAsString(assets, path, dir) {
   let content = readAssetFile(assets, path, dir);
@@ -110,10 +116,11 @@ export function readAssetFileAsString(assets, path, dir) {
 }
 
 /**
- *
- * @param assets
- * @param path
- * @param dir
+ * Get asset content type
+ * @param {object} assets object with assets infos
+ * @param {string} path the asset path
+ * @param {string} dir the reference dir
+ * @returns {string} the file content type
  */
 export function getAssetContentType(assets, path, dir) {
   const relativePath = relative(dir, path);
@@ -122,10 +129,11 @@ export function getAssetContentType(assets, path, dir) {
 }
 
 /**
- *
- * @param assets
- * @param path
- * @param dir
+ * Read manifest files
+ * @param {object} assets object with assets infos
+ * @param {string} path the asset path
+ * @param {string} dir the reference dir
+ * @returns {object} the manifest in JSON format
  */
 export function readAssetManifest(assets, path, dir) {
   const content = readAssetFileAsString(assets, path, dir);
@@ -133,10 +141,11 @@ export function readAssetManifest(assets, path, dir) {
 }
 
 /**
- *
- * @param assets
- * @param path
- * @param dir
+ * Get the asset module
+ * @param {object} assets object with assets infos
+ * @param {string} path the asset path
+ * @param {string} dir the reference dir
+ * @returns {any} asset module
  */
 export function readAssetModule(assets, path, dir) {
   const relativePath = relative(dir, path);
@@ -148,15 +157,15 @@ export function readAssetModule(assets, path, dir) {
  * Finds the path that corresponds to a page, based on the pages manifest and localizations.
  * (An adaptation for Compute@Edge of function in Next.js of the same name,
  * found at next/server/require.ts)
- * @param assets
- * @param page
- * @param srcPage
- * @param dir
- * @param distDir
- * @param serverless
- * @param dev
- * @param locales
- * @param appDirEnabled
+ * @param {object} assets object with assets infos
+ * @param {string} srcPage the page to be analysed
+ * @param {string} dir reference dir
+ * @param {string} distDir reference builded dir
+ * @param {boolean} serverless indicates serverless mode
+ * @param {boolean} dev indicates dev mode
+ * @param {string[]} locales locales from nextjs config
+ * @param {boolean} appDirEnabled indicates if app dir (experimental) is used or not
+ * @returns {string} the page path
  */
 export function getPagePath(
   assets,
@@ -231,12 +240,13 @@ export function getPagePath(
  * Loads the string or module that corresponds to a page.
  * (An adaptation for Compute@Edge of function in Next.js of the same name,
  * found at next/server/require.ts)
- * @param assets
- * @param page
- * @param dir
- * @param distDir
- * @param serverless
- * @param appDirEnabled
+ * @param {object} assets object with assets infos
+ * @param {string} page the page to be analysed
+ * @param {string} dir reference dir
+ * @param {string} distDir reference builded dir
+ * @param {boolean} serverless indicates serverless mode
+ * @param {boolean} appDirEnabled indicates if app dir (experimental) is used or not
+ * @returns {Promise<any>} a promise with the page, page asset module or missing page
  */
 export async function requirePage(
   assets,
@@ -270,10 +280,11 @@ export async function requirePage(
  * Load the font manifest.
  * (An adaptation for Compute@Edge of function in Next.js of the same name,
  * found at next/server/require.ts)
- * @param assets
- * @param distDir
- * @param dir
- * @param serverless
+ * @param {object} assets object with assets infos
+ * @param {string} distDir reference builded dir
+ * @param {string} dir reference dir
+ * @param {boolean} serverless indicates serverless mode
+ * @returns {object} the manifest in JSON format
  */
 export function requireFontManifest(assets, distDir, dir, serverless) {
   const serverBuildPath = join(

--- a/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/serve-static.js
+++ b/lib/presets/custom/next/compute/node/custom-server/12.3.1/server/serve-static.js
@@ -11,11 +11,11 @@ import { getAssetContentType, readAsyncAssetFile } from './require.js';
  * Serves the contents of a file at a path.
  * (A reimplementation for Compute@Edge of function in Next.js of the same name,
  * found at next/server/serve-static.ts)
- * @param assets
- * @param req
- * @param res
- * @param path
- * @param dir
+ * @param {object} assets object with assets infos
+ * @param {object} req the request object
+ * @param {object} res the response object
+ * @param {string} path the asset path
+ * @param {string} dir the reference dir
  */
 export default async function serveStatic(assets, req, res, path, dir) {
   const decodedPath = decodeURIComponent(path);

--- a/lib/presets/custom/next/compute/node/custom-server/12.3.1/util/etag.js
+++ b/lib/presets/custom/next/compute/node/custom-server/12.3.1/util/etag.js
@@ -12,7 +12,8 @@ import crypto from 'crypto';
  * Generates an etag string based on a payload.
  * (An adaptation for Compute@Edge of function in Next.js of the same name,
  * found at next/server/api-utils/web.ts)
- * @param payload
+ * @param {string} payload data to generate etag
+ * @returns {string} the generated etag
  */
 export default function generateETag(payload) {
   if (payload.length === 0) {

--- a/lib/presets/custom/next/compute/node/prebuild/statics/index.js
+++ b/lib/presets/custom/next/compute/node/prebuild/statics/index.js
@@ -5,8 +5,8 @@ import { copyDirectory, feedback } from '#utils';
 
 /**
  * normalize directory path
- * @param {string} dir
- * @returns {string}
+ * @param {string} dir the dir path to normalize
+ * @returns {string} the normalized path
  */
 function normalizeDirPath(dir) {
   const pathNormalize = path.normalize(dir);
@@ -15,8 +15,8 @@ function normalizeDirPath(dir) {
 
 /**
  * is trace file
- * @param {string} pathFile
- * @returns {boolean}
+ * @param {string} pathFile the file path
+ * @returns {boolean} the indication that it is a trace file
  */
 function isTraceFile(pathFile) {
   if (/\b\w+\.nft\.json\b/.test(pathFile) || /\/\.next\/trace/.test(pathFile)) {
@@ -96,9 +96,9 @@ function readDirAndIncludeFiles(
 }
 
 /**
- * Test module
+ * Tests the file to indicate whether it will be treated as a module
  * @param {string} pathFile - path file
- * @returns
+ * @returns {boolean} indicative that the file must be treated as a module
  */
 function moduleTest(pathFile) {
   if (

--- a/lib/presets/custom/next/deliver/handler.js
+++ b/lib/presets/custom/next/deliver/handler.js
@@ -1,4 +1,5 @@
 import { mountSSG } from '#edge';
+import { FetchEvent } from '#typedef';
 
 /**
  * Handles the 'fetch' event.

--- a/lib/presets/custom/react/deliver/handler.js
+++ b/lib/presets/custom/react/deliver/handler.js
@@ -1,4 +1,5 @@
 import { mountSPA, ErrorHTML } from '#edge';
+import { FetchEvent } from '#typedef';
 
 /**
  * Handles the 'fetch' event.

--- a/lib/presets/custom/vue/deliver/handler.js
+++ b/lib/presets/custom/vue/deliver/handler.js
@@ -1,4 +1,5 @@
 import { mountSPA, ErrorHTML } from '#edge';
+import { FetchEvent } from '#typedef';
 
 /**
  * Handles the 'fetch' event.

--- a/lib/presets/default/html/deliver/handler.js
+++ b/lib/presets/default/html/deliver/handler.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { mountSSG } from '#edge';
+import { FetchEvent } from '#typedef';
 
 /**
  * Handles the 'fetch' event.

--- a/lib/presets/default/javascript/compute/handler.js
+++ b/lib/presets/default/javascript/compute/handler.js
@@ -1,3 +1,5 @@
+import { FetchEvent } from '#typedef';
+
 /* eslint-disable */
 __JS_CODE__;
 

--- a/lib/presets/default/typescript/compute/handler.js
+++ b/lib/presets/default/typescript/compute/handler.js
@@ -1,3 +1,5 @@
+import { FetchEvent } from '#typedef';
+
 /* eslint-disable */
 __JS_CODE__;
 

--- a/lib/providers/azion/worker.js
+++ b/lib/providers/azion/worker.js
@@ -1,3 +1,5 @@
+import { FetchEvent } from '#typedef';
+
 /* eslint-disable */
 __HANDLER__;
 

--- a/lib/utils/copyDirectory/copyDirectory.utils.js
+++ b/lib/utils/copyDirectory/copyDirectory.utils.js
@@ -7,12 +7,13 @@ import {
 } from 'fs';
 import { join, resolve } from 'path';
 
+import { Utils } from '#namespaces';
+
 /**
- * Recursively copies a directory to the target directory, excluding any files or directories
- * that would result in the target directory being copied into itself.
  * @function
- * @name copyDirectory
- * @memberof utils
+ * @memberof Utils
+ * @description Recursively copies a directory to the target directory, excluding any files or directories
+ * that would result in the target directory being copied into itself.
  * @param {string} source - The path of the source directory.
  * @param {string} target - The path of the target directory. If the target directory is a
  * subdirectory of the source directory, this function will avoid copying the target directory into

--- a/lib/utils/debug/debug.utils.js
+++ b/lib/utils/debug/debug.utils.js
@@ -1,9 +1,10 @@
+import { Utils } from '#namespaces';
+
 /**
- * Debug method that conditionally logs based on process.env.DEBUG.
- * Inherits all methods from console.log.
  * @function
- * @name debug
- * @memberof utils
+ * @memberof Utils
+ * @description Debug method that conditionally logs based on process.env.DEBUG.
+ * Inherits all methods from console.log.
  * @param {...*} args - Arguments to be logged.
  * @description By default, process.env.DEBUG is set to false.
  * When enabled, this method overrides console.log and allows you to log debug messages during

--- a/lib/utils/exec/exec.utils.js
+++ b/lib/utils/exec/exec.utils.js
@@ -1,11 +1,12 @@
 import { spawn } from 'child_process';
 import signale from 'signale';
 
+import { Utils } from '#namespaces';
+
 /**
- * Execute a command asynchronously and retrieve the standard output and standard error.
  * @function
- * @name exec
- * @memberof utils
+ * @memberof Utils
+ * @description Execute a command asynchronously and retrieve the standard output and standard error.
  * @param {string} command - The command to be executed.
  * @param {string} [scope='Process'] - Log scope. The default is 'Process'.
  * @param {boolean} [verbose=false] - Whether to display the output in real-time.

--- a/lib/utils/feedback/feedback.utils.js
+++ b/lib/utils/feedback/feedback.utils.js
@@ -1,5 +1,7 @@
 import signale from 'signale';
 
+import { Utils } from '#namespaces';
+
 const cleanOutputEnabled = process.env.CLEAN_OUTPUT_MODE === 'true';
 const cleanOutputConfig = {
   displayScope: false,
@@ -124,11 +126,11 @@ const scopes = {
     }),
   },
 };
+
 /**
- * @name feedback
- * @memberof utils
- * @description
- * Feedback object that facilitates log display.
+ * @function
+ * @memberof Utils
+ * @description Feedback object that facilitates log display.
  * It includes all logging methods provided by 'signale'.
  * If the environment variable CLEAN_OUTPUT_MODE is set to 'true', all log methods use console.log,
  * providing cleaner and unstyled output. This is particularly useful

--- a/lib/utils/generateTimestamp/generateTimestamp.utils.js
+++ b/lib/utils/generateTimestamp/generateTimestamp.utils.js
@@ -1,8 +1,9 @@
+import { Utils } from '#namespaces';
+
 /**
- * Generates a timestamp string in the format "YYYYMMDDHHmmss".
  * @function
- * @name generateTimestamp
- * @memberof utils
+ * @memberof Utils
+ * @description Generates a timestamp string in the format "YYYYMMDDHHmmss".
  * @returns {string} The generated timestamp.
  * @example
  *

--- a/lib/utils/generateWebpackBanner/generateWebpackBanner.utils.js
+++ b/lib/utils/generateWebpackBanner/generateWebpackBanner.utils.js
@@ -1,6 +1,11 @@
 import { readFileSync } from 'fs';
+
+import { Utils } from '#namespaces';
+
 /**
- * Generate code to inject in webpack build result initial part.
+ * @function
+ * @memberof Utils
+ * @description Generate code to inject in webpack build result initial part.
  * @param {string[]} filesPaths File paths to use in banner.
  * @returns {string} the created content to inject.
  */

--- a/lib/utils/getAbsoluteLibDirPath/getAbsoluteLibDirPath.utils.js
+++ b/lib/utils/getAbsoluteLibDirPath/getAbsoluteLibDirPath.utils.js
@@ -1,12 +1,13 @@
+import { Utils } from '#namespaces';
+
 const isWindows = process.platform === 'win32';
+
 /**
- * Get the absolute path of the lib directory based on the current module.
  * @function
- * @name getAbsoluteLibDirPath
- * @memberof utils
+ * @memberof Utils
+ * @description Get the absolute path of the lib directory based on the current module.
  * @returns {string} The full path to the lib directory.
  * @example
- *
  * // Example usage:
  * const libDirPath = getAbsoluteLibDirPath();
  * console.log(libDirPath); // 'lib/full/path/to/directory'

--- a/lib/utils/getPackageManager/getPackageManager.utils.js
+++ b/lib/utils/getPackageManager/getPackageManager.utils.js
@@ -2,9 +2,11 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { exec } from 'child_process';
 
+import { Utils } from '#namespaces';
+
 /**
  * @function
- * @name pathExists
+ * @memberof Utils
  * @description Checks if a path exists.
  * @param {string} p - The path to check.
  * @returns {Promise<boolean>} A Promise that resolves to `true`
@@ -22,7 +24,9 @@ async function pathExists(p) {
 const cache = new Map();
 
 /**
- * Check if a global package manager (PM) is available.
+ * @function
+ * @memberof Utils
+ * @description Check if a global package manager (PM) is available.
  * @param {string} pm - The package manager to check (e.g., "npm", "yarn", "pnpm").
  * @returns {Promise<boolean>} A Promise that resolves to true if the global PM is available,
  * false otherwise.
@@ -47,7 +51,9 @@ async function hasGlobalInstallation(pm) {
 }
 
 /**
- * Get the type of lock file (npm, yarn, pnpm) in a specific directory.
+ * @function
+ * @memberof Utils
+ * @description Get the type of lock file (npm, yarn, pnpm) in a specific directory.
  * @param {string} [cwd] - The directory to check. Defaults to the current working directory.
  * @returns {Promise<string|null>} A Promise that resolves to the type of lock file
  * (npm, yarn, pnpm), or null if no lock file is found.
@@ -77,11 +83,9 @@ async function getTypeofLockFile(cwd = '.') {
 }
 
 /**
- * Detects the package manager (npm, yarn, pnpm) being used.
- * @async
  * @function
- * @name getPackageManager
- * @memberof utils
+ * @memberof Utils
+ * @description Detects the package manager (npm, yarn, pnpm) being used.
  * @param {object} options - Options for detecting the package manager.
  * @param {string} [options.cwd] - The directory to check.
  * Defaults to the current working directory.

--- a/lib/utils/getPackageVersion/getPackageVersion.utils.js
+++ b/lib/utils/getPackageVersion/getPackageVersion.utils.js
@@ -1,8 +1,12 @@
 import { join } from 'path';
 import { readFileSync } from 'fs';
 
+import { Utils } from '#namespaces';
+
 /**
- * Get package version from user project.
+ * @function
+ * @memberof Utils
+ * @description Get package version from user project.
  * @param {string} packageName - The depency name.
  * @returns {string} The package version.
  */

--- a/lib/utils/getProjectJsonFile/getProjectJsonFile.utils.js
+++ b/lib/utils/getProjectJsonFile/getProjectJsonFile.utils.js
@@ -1,8 +1,12 @@
 import { join } from 'path';
 import { readFileSync } from 'fs';
 
+import { Utils } from '#namespaces';
+
 /**
- * Reads json file content
+ * @function
+ * @memberof Utils
+ * @description Reads json file content
  * @param {string} filePath - path to json file to be readed.
  * @returns {object} - JSON object with file content.
  */

--- a/lib/utils/getUrlFromResource/getUrlFromResource.utils.js
+++ b/lib/utils/getUrlFromResource/getUrlFromResource.utils.js
@@ -1,5 +1,9 @@
+import { Utils } from '#namespaces';
+
 /**
- * Creates a URL object based on a received resource
+ * @function
+ * @memberof Utils
+ * @description Creates a URL object based on a received resource
  * @param {URL|Request|string} resource received resource.
  * @returns {URL} Generated URL object.
  */

--- a/lib/utils/getVulcanBuildId/getVulcanBuildId.utils.js
+++ b/lib/utils/getVulcanBuildId/getVulcanBuildId.utils.js
@@ -1,10 +1,11 @@
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
+import { Utils } from '#namespaces';
+
 /**
- * @memberof utils
  * @function
- * @name getVulcanBuildId
+ * @memberof Utils
  * @description Fetches the unique build ID for the current project from the
  * .env file in the .edge directory.
  * The build ID is a unique identifier for a specific version of the project's

--- a/lib/utils/overrideStaticOutputPath/overrideStaticOutputPath.utils.js
+++ b/lib/utils/overrideStaticOutputPath/overrideStaticOutputPath.utils.js
@@ -1,11 +1,11 @@
 import { readFileSync, writeFileSync } from 'fs';
 
+import { Utils } from '#namespaces';
+
 /**
- * Overrides the output path for static files in a provided configuration file.
- * @
  * @function
- * @name overrideStaticOutputPath
- * @memberof utils
+ * @memberof Utils
+ * @description Overrides the output path for static files in a provided configuration file.
  * @param {string} configFilePath - The path to the configuration file to be modified.
  * @param {RegExp} regexPattern - The RegExp object to be used
  * for matching within the configuration file.

--- a/lib/utils/presets/presets.utils.js
+++ b/lib/utils/presets/presets.utils.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import { Utils } from '#namespaces';
+
 const isWindows = process.platform === 'win32';
 const currentModuleFullPath = import.meta.url;
 let baselibPath = currentModuleFullPath.match(/(.*lib)(.*)/)[1];
@@ -16,12 +18,11 @@ if (!isWindows) {
 }
 
 /**
- * Retrieves a list of presets from 'default' and 'custom' directories in a beautified format.
+ * @function
+ * @memberof Utils
+ * @description Retrieves a list of presets from 'default' and 'custom' directories in a beautified format.
  * Unlike `getKeys`, this method returns preset names formatted
  * for display and includes modes like '(Deliver)' or '(Compute)'.
- * @function
- * @memberof presets
- * @name getBeautify
  * @param {string[]} [types=['default', 'custom']] - The types of presets to list.
  * Each type corresponds to a folder in the 'presets' directory.
  * @returns {string[]} The list of presets with modes like '(Deliver)' or '(Compute)' if applicable.
@@ -66,13 +67,12 @@ function getBeautify(types = ['default', 'custom']) {
 }
 
 /**
- * Retrieves an array of valid preset keys by scanning through
+ * @function
+ * @memberof Utils
+ * @description Retrieves an array of valid preset keys by scanning through
  * the preset directories 'default' and 'custom'.
  * Each folder name in these directories is considered as a valid preset key.
  * Unlike `getBeautify`, this method returns raw preset names without any formatting or modes.
- * @function
- * @memberof presets
- * @name getKeys
  * @returns {string[]} An array of valid build presets.
  * @example
  * const validPresetsKeys = getKeys();
@@ -98,11 +98,10 @@ function getKeys() {
 }
 
 /**
- * Creates a new preset in the lib/presets/custom/${mode} directory.
- * Also generates three required files: handler.js, prebuild.js, and config.js.
  * @function
- * @memberof utils
- * @name set
+ * @memberof Utils
+ * @description Creates a new preset in the lib/presets/custom/${mode} directory.
+ * Also generates three required files: handler.js, prebuild.js, and config.js.
  * @param {string} name - The name of the new preset.
  * @param {'compute'|'deliver'} mode - The mode for the preset, either 'compute' or 'deliver'.
  * @throws {Error} Throws an error if a preset with the same name
@@ -144,12 +143,11 @@ function set(name, mode) {
 }
 
 /**
- * Retrieves an array of available modes for a given preset by scanning
+ * @function
+ * @memberof Utils
+ * @description Retrieves an array of available modes for a given preset by scanning
  * through the preset directories 'default' and 'custom'.
  * Each sub-folder name in these directories is considered as a valid mode for the preset.
- * @function
- * @memberof presets
- * @name getModes
  * @param {string} presetName - The name of the preset for which modes are to be retrieved.
  * @returns {string[]} An array of available modes for the given preset.
  * @example
@@ -179,8 +177,9 @@ function getModes(presetName) {
 }
 
 /**
- * Presets object containing utility functions for working with build presets.
- * @memberof utils
+ * @function
+ * @memberof Utils
+ * @description Presets object containing utility functions for working with build presets.
  * @property {Function} getKeys - Function to retrieve an array of valid preset keys.
  * These keys are raw and do not include any modes or formatting.
  * @property {Function} getBeautify - Function to retrieve a list of presets in a beautified format.

--- a/lib/utils/readWorkerFile/readWorkerFile.utils.js
+++ b/lib/utils/readWorkerFile/readWorkerFile.utils.js
@@ -1,11 +1,11 @@
 import fs from 'fs/promises';
 
+import { Utils } from '#namespaces';
+
 /**
- * Reads the content of a worker file.
- * @async
  * @function
- * @name readWorkerFile
- * @memberof utils
+ * @memberof Utils
+ * @description Reads the content of a worker file.
  * @param {string} filePath - The path to the worker file.
  * @returns {Promise<string>} A Promise that resolves to the content of the worker file.
  * @throws {Error} Will throw an error if the file doesn't exist or there was an error reading it.

--- a/lib/utils/spinner/spinner.utils.js
+++ b/lib/utils/spinner/spinner.utils.js
@@ -1,5 +1,12 @@
 import signale from 'signale';
 
+import { Utils } from '#namespaces';
+
+/**
+ * @class
+ * @memberof Utils
+ * @description Terminal Spinner
+ */
 class Spinner {
   constructor(action) {
     this.action = action;

--- a/lib/utils/vercel/vercel.utils.js
+++ b/lib/utils/vercel/vercel.utils.js
@@ -2,8 +2,12 @@ import { rmSync, existsSync, mkdirSync, writeFileSync } from 'fs';
 import { spawn } from 'child_process';
 import { join } from 'path';
 
+import { Utils } from '#namespaces';
+
 /**
- * Delete Next.js telemetry files created in build.
+ * @function
+ * @memberof Utils
+ * @description Delete Next.js telemetry files created in build.
  */
 function deleteTelemetryFiles() {
   const dirPath = join('.vercel', 'output', 'static', '_next', '__private');
@@ -12,7 +16,9 @@ function deleteTelemetryFiles() {
 }
 
 /**
- * Create vercel config file when needed.
+ * @function
+ * @memberof Utils
+ * @description Create vercel config file when needed.
  */
 function createVercelProjectConfig() {
   try {
@@ -35,7 +41,9 @@ function createVercelProjectConfig() {
 }
 
 /**
- * Run vercel cli build for production environment.
+ * @function
+ * @memberof Utils
+ * @description Run vercel cli build for production environment.
  */
 async function runVercelBuild() {
   // https://vercel.com/docs/build-output-api/v3

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "#build": "./lib/build/dispatcher/index.js",
     "#bundlers": "./lib/build/bundlers/index.js",
     "#notations/*": "./lib/notations",
+    "#namespaces": "./lib/notations/namespaces.js",
     "#env": "./lib/env/index.js",
     "#platform": "./lib/platform/index.js",
     "#constants": "./lib/constants/index.js",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "eslint-plugin-jsdoc": "^44.2.5",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.7.0",
+    "jsdoc": "^4.0.2",
     "mock-fs": "^5.2.0",
     "prettier": "^3.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "#bundlers": "./lib/build/bundlers/index.js",
     "#notations/*": "./lib/notations",
     "#namespaces": "./lib/notations/namespaces.js",
+    "#typedef": "./lib/notations/typedef.js",
     "#env": "./lib/env/index.js",
     "#platform": "./lib/platform/index.js",
     "#constants": "./lib/constants/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,6 +450,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.16.tgz#180aead7f247305cce6551bea2720934e2fa2c95"
   integrity sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==
 
+"@babel/parser@^7.20.15":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.0.tgz#da950e622420bf96ca0d0f2909cdddac3acd8719"
+  integrity sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==
+
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.22.15":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.22.15.tgz#02dc8a03f613ed5fdc29fb2f728397c78146c962"
@@ -1794,7 +1799,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jsdoc/salty@^0.2.4":
+"@jsdoc/salty@^0.2.1", "@jsdoc/salty@^0.2.4":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@jsdoc/salty/-/salty-0.2.5.tgz#1b2fa5bb8c66485b536d86eee877c263d322f692"
   integrity sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==
@@ -2696,10 +2701,28 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/linkify-it@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.3.tgz#15a0712296c5041733c79efe233ba17ae5a7587b"
+  integrity sha512-pTjcqY9E4nOI55Wgpz7eiI8+LzdYnw3qxXCfHyBDdPbYvbyLgWLJGh8EdPvqawwMK1Uo1794AUkkR38Fr0g+2g==
+
 "@types/long@^4.0.0":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
   integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
+
+"@types/markdown-it@^12.2.3":
+  version "12.2.3"
+  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-12.2.3.tgz#0d6f6e5e413f8daaa26522904597be3d6cd93b51"
+  integrity sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==
+  dependencies:
+    "@types/linkify-it" "*"
+    "@types/mdurl" "*"
+
+"@types/mdurl@*":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
+  integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
 
 "@types/mime@*":
   version "3.0.1"
@@ -4229,6 +4252,13 @@ cardinal@^2.1.1:
     ansicolors "~0.3.2"
     redeyed "~2.1.0"
 
+catharsis@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.9.0.tgz#40382a168be0e6da308c277d3a2b3eb40c7d2121"
+  integrity sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==
+  dependencies:
+    lodash "^4.17.15"
+
 caw@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/caw/-/caw-2.0.1.tgz#6c3ca071fc194720883c2dc5da9b074bfc7e9e95"
@@ -5411,6 +5441,11 @@ entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
 env-ci@^9.0.0:
   version "9.1.1"
@@ -6700,7 +6735,7 @@ graceful-fs@4.2.10:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -8304,6 +8339,13 @@ js-yaml@^4.0.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+js2xmlparser@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-4.0.2.tgz#2a1fdf01e90585ef2ae872a01bc169c6a8d5e60a"
+  integrity sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==
+  dependencies:
+    xmlcreate "^2.0.4"
+
 jscodeshift@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.11.0.tgz#4f95039408f3f06b0e39bb4d53bc3139f5330e2f"
@@ -8333,6 +8375,27 @@ jsdoc-type-pratt-parser@~4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz#136f0571a99c184d84ec84662c45c29ceff71114"
   integrity sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==
+
+jsdoc@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-4.0.2.tgz#a1273beba964cf433ddf7a70c23fd02c3c60296e"
+  integrity sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==
+  dependencies:
+    "@babel/parser" "^7.20.15"
+    "@jsdoc/salty" "^0.2.1"
+    "@types/markdown-it" "^12.2.3"
+    bluebird "^3.7.2"
+    catharsis "^0.9.0"
+    escape-string-regexp "^2.0.0"
+    js2xmlparser "^4.0.2"
+    klaw "^3.0.0"
+    markdown-it "^12.3.2"
+    markdown-it-anchor "^8.4.1"
+    marked "^4.0.10"
+    mkdirp "^1.0.4"
+    requizzle "^0.2.3"
+    strip-json-comments "^3.1.0"
+    underscore "~1.13.2"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -8479,6 +8542,13 @@ klaw-sync@^6.0.0:
   integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
   dependencies:
     graceful-fs "^4.1.11"
+
+klaw@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-3.0.0.tgz#b11bec9cf2492f06756d6e809ab73a2910259146"
+  integrity sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==
+  dependencies:
+    graceful-fs "^4.1.9"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -8628,6 +8698,13 @@ lines-and-columns@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-2.0.3.tgz#b2f0badedb556b747020ab8ea7f0373e22efac1b"
   integrity sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==
+
+linkify-it@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
+  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+  dependencies:
+    uc.micro "^1.0.1"
 
 load-json-file@^4.0.0:
   version "4.0.0"
@@ -8930,6 +9007,22 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it-anchor@^8.4.1:
+  version "8.6.7"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz#ee6926daf3ad1ed5e4e3968b1740eef1c6399634"
+  integrity sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==
+
+markdown-it@^12.3.2:
+  version "12.3.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
+  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~2.1.0"
+    linkify-it "^3.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 marked-terminal@^5.1.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-5.2.0.tgz#c5370ec2bae24fb2b34e147b731c94fa933559d3"
@@ -8941,6 +9034,11 @@ marked-terminal@^5.1.1:
     cli-table3 "^0.6.3"
     node-emoji "^1.11.0"
     supports-hyperlinks "^2.3.0"
+
+marked@^4.0.10:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 marked@^5.0.0:
   version "5.1.2"
@@ -8955,6 +9053,11 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -9217,7 +9320,7 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "^1.2.6"
 
-mkdirp@^1.0.3:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -10966,6 +11069,13 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
+requizzle@^0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.4.tgz#319eb658b28c370f0c20f968fa8ceab98c13d27c"
+  integrity sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==
+  dependencies:
+    lodash "^4.17.21"
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -11883,7 +11993,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.1.1:
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -12405,6 +12515,11 @@ typescript@~4.5.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
 uglify-js@^3.1.4:
   version "3.17.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
@@ -12432,6 +12547,11 @@ unbzip2-stream@^1.0.9:
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
+
+underscore@~1.13.2:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
+  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
@@ -12924,6 +13044,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmlcreate@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-2.0.4.tgz#0c5ab0f99cdd02a81065fa9cd8f8ae87624889be"
+  integrity sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==
 
 xss@^1.0.8:
   version "1.0.14"


### PR DESCRIPTION
In this PR:
- Add missing jsdocs;
- Fix jsdocs namespaces use;
- Fix logs in get asset from storage method (next compute handler code);
- Add FetchEvent type definition in jsdocs;

Testing:
- Run `yarn lint` and check problems (must be 0);
- Run `yarn task:docs` and open generate index file (`jsdoc/edge-functions/1.7.0/index.html`) in browser. Check the generated docs navigating in namespaces; 
