### PR TITLE
feat: vulcan.config.js

### DIFF
--- a/lib/build/bundlers/esbuild/index.js
+++ b/lib/build/bundlers/esbuild/index.js
@@ -10,7 +10,8 @@ import { NodeModulesPolyfillPlugin } from './plugins/node-polyfills/index.js';
 class Esbuild {
   constructor(builderConfig) {
     this.builderConfig = builderConfig;
-    this.customConfig = builderConfig.custom;
+    this.customConfigPreset = builderConfig.custom;
+    this.customConfigLocal = builderConfig.localCustom;
   }
 
   run = async () => {
@@ -20,14 +21,15 @@ class Esbuild {
       AZION_VERSION_ID: JSON.stringify(this.builderConfig.buildId),
     };
 
-    const hasCustomConfig = Object.keys(this.customConfig).length > 0;
+    const hasCustomConfig = Object.keys(this.customConfigPreset).length > 0;
     if (hasCustomConfig) {
-      config = merge(this.customConfig, config);
+      config = merge(this.customConfigPreset, this.customConfigLocal, config);
     }
 
     if (
       this.builderConfig.useNodePolyfills ||
-      this.customConfig.useNodePolyfills
+      this.customConfigPreset.useNodePolyfills ||
+      this.customConfigLocal
     ) {
       if (!config.plugins) config.plugins = [];
 

--- a/lib/build/bundlers/webpack/index.js
+++ b/lib/build/bundlers/webpack/index.js
@@ -10,7 +10,8 @@ import AzionWebpackConfig from './webpack.config.js';
 class Webpack {
   constructor(builderConfig) {
     this.builderConfig = builderConfig;
-    this.customConfig = builderConfig.custom;
+    this.customConfigPreset = builderConfig.custom;
+    this.customConfigLocal = builderConfig.localCustom;
   }
 
   run = async () => {
@@ -25,9 +26,9 @@ class Webpack {
       ...config.plugins,
     ];
 
-    const hasCustomConfig = Object.keys(this.customConfig).length > 0;
+    const hasCustomConfig = Object.keys(this.customConfigPreset).length > 0;
     if (hasCustomConfig) {
-      config = merge(this.customConfig, config);
+      config = merge(this.customConfigPreset, this.customConfigLocal, config);
     }
 
     try {

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -46,130 +46,6 @@ async function getAliasPath(alias) {
 }
 
 /**
- * Get a build context based on arguments
- * @param {string} preset - The build preset.
- * @param {string} entry - The entrypoint file path.
- * @param {string} mode - The mode of preset build.
- * @param {boolean} useOwnWorker - The mode of preset build.
- * @returns {any} This flag indicates that the constructed code inserts its own worker (provider) expression.
- */
-async function loadBuildContext(preset, entry, mode, useOwnWorker) {
-  const VALID_BUILD_PRESETS = presets.getKeys();
-
-  const validPreset = VALID_BUILD_PRESETS.includes(preset);
-
-  if (!validPreset) {
-    feedback.build.error(Messages.build.error.invalid_preset);
-    process.exit(1);
-  }
-
-  let configFilePath;
-  let prebuildFilePath;
-  let handlerFilePath;
-
-  const defaultModePath = join(
-    vulcanLibPath,
-    'presets',
-    'default',
-    preset,
-    mode,
-  );
-  const customModePath = join(vulcanLibPath, 'presets', 'custom', preset, mode);
-  let modePath;
-
-  // Check if the 'mode' folder exists within the default or custom preset paths
-  if (existsSync(defaultModePath)) {
-    modePath = defaultModePath;
-  } else if (existsSync(customModePath)) {
-    modePath = customModePath;
-  }
-
-  if (modePath) {
-    configFilePath = join(modePath, 'config.js');
-    prebuildFilePath = join(modePath, 'prebuild.js');
-    handlerFilePath = join(modePath, 'handler.js');
-  } else {
-    feedback.build.error(
-      Messages.build.error.invalid_preset_mode(mode, preset),
-    );
-    process.exit(1);
-  }
-
-  configFilePath = new URL(`file://${configFilePath}`).href;
-  prebuildFilePath = new URL(`file://${prebuildFilePath}`).href;
-
-  const config = (await import(configFilePath)).default;
-
-  const prebuild = (await import(prebuildFilePath)).default;
-  const handlerTemplate = readFileSync(handlerFilePath, 'utf-8');
-  const handlerTemplateBody = getExportedFunctionBody(handlerTemplate);
-
-  let newEntryContent;
-
-  // use providers
-  if (useOwnWorker) {
-    newEntryContent = `(async function() {
-      ${handlerTemplateBody}
-    })()`;
-  }
-
-  if (!useOwnWorker) {
-    const workerFilePath = join(
-      vulcanLibPath,
-      'providers',
-      'azion',
-      'worker.js',
-    );
-
-    const workerTemplate = readFileSync(workerFilePath, 'utf-8');
-    newEntryContent = workerTemplate.replace(
-      '__HANDLER__',
-      `(async function() {
-        ${handlerTemplateBody}
-      })()`,
-    );
-  }
-
-  // resolve #edge alias without vulcan context
-  const edgehooksPath = await getAliasPath('edge');
-  newEntryContent = newEntryContent?.replace('#edge', edgehooksPath);
-
-  if (
-    (preset === 'javascript' || preset === 'typescript') &&
-    mode === 'compute'
-  ) {
-    try {
-      const filePath = join(process.cwd(), entry);
-      const entryContent = readFileSync(filePath, 'utf-8');
-
-      if (useOwnWorker) {
-        newEntryContent = newEntryContent.replace('__JS_CODE__', entryContent);
-      }
-      if (!useOwnWorker) {
-        const entrypointModified = getExportedFunctionBody(entryContent);
-        newEntryContent = newEntryContent.replace(
-          '__JS_CODE__',
-          entrypointModified,
-        );
-      }
-    } catch (error) {
-      feedback.build.error(error.message);
-      debug.error(error);
-      process.exit(1);
-    }
-  }
-  newEntryContent = relocateImportsAndRequires(newEntryContent);
-
-  const buildContext = {
-    entryContent: newEntryContent,
-    prebuild,
-    config,
-  };
-
-  return buildContext;
-}
-
-/**
 Create a .env file in the build folder with specified parameters.
  * @param {string} buildId - The version ID to write into the .env file.
  */
@@ -203,9 +79,13 @@ async function folderExistsInProject(folder) {
   }
 }
 /**
- * Check if node_modules dir exists
+ * Check if the project has a package.json file and if it has dependencies or
+ * devDependencies, it then checks if the node_modules folder exists and exits the process if it
+ * doesn't.
+ * @returns {Promise<void>} The function does not have an explicit return statement. Therefore, it does not return any
+ * value.
  */
-async function checkNodeModulesDir() {
+async function checkNodeModules() {
   let projectJson;
   try {
     projectJson = getProjectJsonFile('package.json');
@@ -242,59 +122,203 @@ async function checkNodeModulesDir() {
  */
 class Dispatcher {
   /**
-   * Create a Dispatcher.
-   * @param {string} preset - The preset for the build.
-   * @param {string} mode - The mode of build target.
-   * @param {string} entry - The entry point for the build.
-   * @param {boolean} useNodePolyfills - The flag to indicates polyfills use.
-   * @param {boolean} useOwnWorker - This flag indicates that the constructed code inserts its own worker expression,
-   * such as addEventListener("fetch") or similar, without the need to inject a provider.
+   * Create a build configuration object.
+   * @param {object} config - The configuration object.
+   * @param {string} [config.entry] - The entry point for the build.
+   * @param {string}[config.builder] - The name of the Bundler you want to use (Esbuild or Webpack)
+   * @param {object} [config.preset] - The preset configuration for the build.
+   * @param {string} [config.preset.name] - The name of the preset.
+   * @param {string} [config.preset.mode] - The mode of the build target.
+   * @param {boolean} [config.useNodePolyfills] - Flag indicating whether to use Node.js polyfills.
+   * @param {boolean} [config.useOwnWorker] - Flag indicating whether the constructed code inserts its own worker expression without the need to inject a provider.
+   * @param {string[]|undefined} [config.memoryFS] - Reference to dirs that contains files to be injected in worker memory.
+   * @param {object} [config.custom] - Custom Bundle configuration.
    */
-  constructor(preset, mode, entry, useNodePolyfills, useOwnWorker) {
-    this.preset = preset;
-    this.mode = mode;
-    this.entry = entry;
-    this.useNodePolyfills = useNodePolyfills;
-    this.useOwnWorker = useOwnWorker;
+  constructor(config) {
+    /* configuration */
+    this.entry = config.entry;
+    this.builder = config.builder;
+    this.preset = config.preset;
+    this.useNodePolyfills =
+      config.useNodePolyfills === 'true' || config.useNodePolyfills === true;
+    this.useOwnWorker =
+      config.useOwnWorker === 'true' || config.useOwnWorker === true;
+    this.memoryFS = config.memoryFS;
+    this.custom = config.custom;
+    /* generate */
     this.buildId = generateTimestamp();
+  }
+
+  /**
+   * Get a build context based on arguments
+   * @returns {object} - Preset files
+   */
+  async loadPreset() {
+    const VALID_BUILD_PRESETS = presets.getKeys();
+
+    const validPreset = VALID_BUILD_PRESETS.includes(this.preset.name);
+
+    if (!validPreset) {
+      feedback.build.error(Messages.build.error.invalid_preset);
+      process.exit(1);
+    }
+
+    let configFilePath;
+    let prebuildFilePath;
+    let handlerFilePath;
+
+    const defaultModePath = join(
+      vulcanLibPath,
+      'presets',
+      'default',
+      this.preset.name,
+      this.preset.mode,
+    );
+    const customModePath = join(
+      vulcanLibPath,
+      'presets',
+      'custom',
+      this.preset.name,
+      this.preset.mode,
+    );
+    let modePath;
+
+    // Check if the 'mode' folder exists within the default or custom preset paths
+    if (existsSync(defaultModePath)) {
+      modePath = defaultModePath;
+    } else if (existsSync(customModePath)) {
+      modePath = customModePath;
+    }
+
+    if (modePath) {
+      configFilePath = join(modePath, 'config.js');
+      prebuildFilePath = join(modePath, 'prebuild.js');
+      handlerFilePath = join(modePath, 'handler.js');
+    } else {
+      feedback.build.error(
+        Messages.build.error.invalid_preset_mode(
+          this.preset.mode,
+          this.preset.name,
+        ),
+      );
+      process.exit(1);
+    }
+
+    configFilePath = new URL(`file://${configFilePath}`).href;
+    prebuildFilePath = new URL(`file://${prebuildFilePath}`).href;
+
+    const config = (await import(configFilePath)).default;
+
+    const prebuild = (await import(prebuildFilePath)).default;
+    const handlerTemplate = readFileSync(handlerFilePath, 'utf-8');
+    const handlerTemplateBody = getExportedFunctionBody(handlerTemplate);
+
+    let newHandlerContent;
+
+    if (this.useOwnWorker) {
+      newHandlerContent = `(async function() {
+      ${handlerTemplateBody}
+    })()`;
+    }
+
+    // use providers
+    if (!this.useOwnWorker) {
+      const workerFilePath = join(
+        vulcanLibPath,
+        'providers',
+        'azion',
+        'worker.js',
+      );
+
+      const workerTemplate = readFileSync(workerFilePath, 'utf-8');
+      newHandlerContent = workerTemplate.replace(
+        '__HANDLER__',
+        `(async function() {
+        ${handlerTemplateBody}
+      })()`,
+      );
+    }
+
+    // resolve #edge alias without vulcan context
+    const edgehooksPath = await getAliasPath('edge');
+    newHandlerContent = newHandlerContent?.replace('#edge', edgehooksPath);
+
+    if (
+      (this.preset.name === 'javascript' ||
+        this.preset.name === 'typescript') &&
+      this.preset.mode === 'compute'
+    ) {
+      try {
+        const filePath = join(process.cwd(), this.entry);
+        const handlerContent = readFileSync(filePath, 'utf-8');
+
+        if (this.useOwnWorker) {
+          newHandlerContent = newHandlerContent.replace(
+            '__JS_CODE__',
+            handlerContent,
+          );
+        }
+        if (!this.useOwnWorker) {
+          const entrypointModified = getExportedFunctionBody(handlerContent);
+          newHandlerContent = newHandlerContent.replace(
+            '__JS_CODE__',
+            entrypointModified,
+          );
+        }
+      } catch (error) {
+        feedback.build.error(error.message);
+        debug.error(error);
+        process.exit(1);
+      }
+    }
+    newHandlerContent = relocateImportsAndRequires(newHandlerContent);
+
+    const files = {
+      handler: newHandlerContent,
+      prebuild,
+      config,
+    };
+
+    return files;
   }
 
   /**
    * Run the build process.
    */
-  run = async () => {
-    await checkNodeModulesDir();
+  async run() {
+    await checkNodeModules();
 
-    // Load Context based on preset
-    const { entryContent, prebuild, config } = await loadBuildContext(
-      this.preset,
-      this.entry,
-      this.mode,
-      this.useOwnWorker,
-    );
+    // Load files from preset
+    const { handler, prebuild, config } = await this.loadPreset();
 
-    const buildContext = {
-      preset: this.preset,
-      mode: this.mode,
+    const context = {
+      buildId: this.buildId,
       entry: this.entry,
-      entryContent,
-      config,
       useNodePolyfills: this.useNodePolyfills,
       useOwnWorker: this.useOwnWorker,
-      buildId: this.buildId,
+      memoryFS: this.memoryFS,
+      preset: {
+        name: this.preset.name,
+        mode: this.preset.mode,
+        files: {
+          handler,
+          config,
+          prebuild,
+        },
+      },
     };
 
     const currentDir = process.cwd();
     let tempEntryFile = `vulcan-${this.buildId}.temp.`;
-    tempEntryFile += this.preset === 'typescript' ? 'ts' : 'js';
+    tempEntryFile += this.preset.name === 'typescript' ? 'ts' : 'js';
     const tempBuilderEntryPath = join(currentDir, tempEntryFile);
 
-    writeFileSync(tempBuilderEntryPath, entryContent);
+    writeFileSync(tempBuilderEntryPath, handler);
 
     // Run prebuild actions
     try {
       feedback.prebuild.info(Messages.build.info.prebuild_starting);
-      await prebuild(buildContext);
+      await prebuild(context);
       createDotEnvFile(this.buildId);
       feedback.prebuild.success(Messages.build.success.prebuild_succeeded);
 
@@ -305,9 +329,11 @@ class Dispatcher {
       config.buildId = this.buildId;
       config.useNodePolyfills = this.useNodePolyfills;
       config.useOwnWorker = this.useOwnWorker;
+      config.localCustom = this.custom;
 
+      const builderSelected = this.builder || config.builder;
       let builder;
-      switch (config.builder) {
+      switch (builderSelected) {
         case 'webpack':
           builder = new Webpack(config);
           break;
@@ -328,8 +354,8 @@ class Dispatcher {
       await vulcan.createVulcanEnv(
         {
           entry: this.entry,
-          preset: this.preset,
-          mode: this.mode,
+          preset: this.preset.name,
+          mode: this.preset.mode,
           ...(this.useNodePolyfills !== null && {
             useNodePolyfills: this.useNodePolyfills,
           }),
@@ -346,7 +372,7 @@ class Dispatcher {
       feedback.build.error(error);
       process.exit(1);
     }
-  };
+  }
 }
 
 export default Dispatcher;

--- a/lib/commands/build.commands.js
+++ b/lib/commands/build.commands.js
@@ -3,6 +3,56 @@ import { feedback } from '#utils';
 import { vulcan } from '#env';
 
 /**
+ * Retrieves a configuration value based on priority.
+ * Priority order: customConfig, inputOption, vulcanVariable, defaultValue.
+ * @param {any} customConfig - Configuration from custom module.
+ * @param {any} inputOption - Configuration provided as input.
+ * @param {any} vulcanVariable - Configuration from the .vulcan file.
+ * @param {any} defaultValue - Default value to use if no other configurations are available.
+ * @returns {any} The chosen configuration value.
+ */
+function getConfigValue(
+  customConfig,
+  inputOption,
+  vulcanVariable,
+  defaultValue,
+) {
+  return customConfig ?? inputOption ?? vulcanVariable ?? defaultValue;
+}
+
+/**
+ * Retrieves a preset configuration value based on priority.
+ * Priority order for both name and mode: customConfig, inputOption, vulcanVariable, defaultValue.
+ * @param {object} customConfig - Preset configuration from custom module.
+ * @param {string} presetName - Preset name provided as input.
+ * @param {string} presetMode - Preset mode provided as input.
+ * @param {object} vulcanVariable - Preset configuration from the .vulcan file.
+ * @param {object} defaultValue - Default preset configuration.
+ * @returns {object} The chosen preset configuration with name and mode.
+ */
+function getPresetValue(
+  customConfig,
+  presetName,
+  presetMode,
+  vulcanVariable,
+  defaultValue,
+) {
+  const name = getConfigValue(
+    customConfig?.name,
+    presetName,
+    vulcanVariable?.preset,
+    defaultValue?.name,
+  );
+  const mode = getConfigValue(
+    customConfig?.mode,
+    presetMode,
+    vulcanVariable?.mode,
+    defaultValue?.mode,
+  );
+  return { name, mode };
+}
+
+/**
  * A command to initiate the build process.
  * This command prioritizes parameters over .vulcan file configurations.
  * If a parameter is provided, it uses the parameter value,
@@ -11,6 +61,7 @@ import { vulcan } from '#env';
  * @memberof Commands
  * @param {object} options - Configuration options for the build command.
  * @param {string} [options.entry] - The entry point file for the build.
+ * @param {string}[options.builder] - The name of the Bundler you want to use (Esbuild or Webpack)
  * @param {string} [options.preset] - Preset to be used (e.g., 'javascript', 'typescript').
  * @param {string} [options.mode] - Mode in which to run the build (e.g., 'deliver', 'compute').
  * @param {boolean} [options.useNodePolyfills] - Whether to use Node.js polyfills.
@@ -27,40 +78,72 @@ import { vulcan } from '#env';
  */
 async function buildCommand({
   entry,
+  builder,
   preset,
   mode,
   useNodePolyfills,
   useOwnWorker,
 }) {
-  let config = {
-    entry,
-    preset,
-    mode,
-    useNodePolyfills,
-    useOwnWorker,
-  };
-
+  const customConfigurationModule = await vulcan.loadVulcanConfigFile();
   const vulcanVariables = await vulcan.readVulcanEnv('local');
 
-  // If no arguments are provided, use the .vulcan file configurations
-  config = {
-    entry: entry ?? vulcanVariables?.entry ?? './main.js',
-    preset: preset ?? vulcanVariables?.preset ?? 'javascript',
-    mode: mode ?? vulcanVariables?.mode ?? 'compute',
-    useNodePolyfills:
-      useNodePolyfills ?? vulcanVariables?.useNodePolyfills ?? null,
-    useOwnWorker: useOwnWorker ?? vulcanVariables?.useOwnWorker ?? null,
+  const config = {
+    entry: getConfigValue(
+      customConfigurationModule?.entry,
+      entry,
+      vulcanVariables?.entry,
+      preset === 'typescript' ? './main.ts' : './main.js',
+    ),
+    builder: getConfigValue(
+      customConfigurationModule?.builder,
+      builder,
+      vulcanVariables?.builder,
+      null,
+    ),
+    memoryFS: {
+      injectionDirs: getConfigValue(
+        customConfigurationModule?.memoryFS?.injectionDirs,
+        null,
+        null,
+        null,
+      ),
+      removePathPrefix: getConfigValue(
+        customConfigurationModule?.memoryFS?.removePathPrefix,
+        null,
+        null,
+        null,
+      ),
+    },
+    useNodePolyfills: getConfigValue(
+      customConfigurationModule?.useNodePolyfills,
+      useNodePolyfills,
+      vulcanVariables?.useNodePolyfills,
+      false,
+    ),
+    useOwnWorker: getConfigValue(
+      customConfigurationModule?.useOwnWorker,
+      useOwnWorker,
+      vulcanVariables?.useOwnWorker,
+      false,
+    ),
+    preset: getPresetValue(
+      customConfigurationModule?.preset,
+      preset,
+      mode,
+      vulcanVariables,
+      { name: 'javascript', mode: 'compute' },
+    ),
+    custom: customConfigurationModule?.custom ?? {},
   };
-  feedback.info(`Using ${config.entry} as entry point by default`);
 
+  if (
+    config.preset.name === 'javascript' ||
+    config.preset.name === 'typescript'
+  ) {
+    feedback.info(`Using ${config.entry} as entrypoint...`);
+  }
   const BuildDispatcher = (await import('#build')).default;
-  const buildDispatcher = new BuildDispatcher(
-    config.preset,
-    config.mode,
-    config.entry,
-    config.useNodePolyfills,
-    config.useOwnWorker,
-  );
+  const buildDispatcher = new BuildDispatcher(config);
 
   await buildDispatcher.run();
 }

--- a/lib/env/vulcan.env.js
+++ b/lib/env/vulcan.env.js
@@ -1,6 +1,7 @@
 import { feedback, debug } from '#utils';
 import { Messages } from '#constants';
-import fs from 'fs/promises';
+import fs from 'fs';
+import fsPromises from 'fs/promises';
 import path from 'path';
 
 /**
@@ -30,7 +31,7 @@ async function createVulcanEnv(variables, scope = 'global') {
   const vulcanEnvPath = path.join(basePath, '.vulcan');
 
   try {
-    await fs.mkdir(basePath, { recursive: true });
+    await fsPromises.mkdir(basePath, { recursive: true });
   } catch (error) {
     debug.error(error);
     feedback.error(Messages.errors.folder_creation_failed(vulcanEnvPath));
@@ -39,7 +40,7 @@ async function createVulcanEnv(variables, scope = 'global') {
 
   let envData = '';
   try {
-    envData = await fs.readFile(vulcanEnvPath, 'utf8');
+    envData = await fsPromises.readFile(vulcanEnvPath, 'utf8');
   } catch (error) {
     if (error.code !== 'ENOENT') {
       debug.error(error);
@@ -60,7 +61,7 @@ async function createVulcanEnv(variables, scope = 'global') {
   });
 
   try {
-    await fs.writeFile(vulcanEnvPath, envData);
+    await fsPromises.writeFile(vulcanEnvPath, envData);
   } catch (error) {
     debug.error(error);
     feedback.error(Messages.errors.write_file_failed(vulcanEnvPath));
@@ -101,8 +102,8 @@ async function readVulcanEnv(scope = 'global') {
   const vulcanEnvPath = path.join(basePath, '.vulcan');
 
   try {
-    await fs.access(vulcanEnvPath);
-    const fileContents = await fs.readFile(vulcanEnvPath, 'utf8');
+    await fsPromises.access(vulcanEnvPath);
+    const fileContents = await fsPromises.readFile(vulcanEnvPath, 'utf8');
 
     const variables = {};
     const variableRegex = /^([^=]+)=(.*)$/gm;
@@ -125,4 +126,32 @@ async function readVulcanEnv(scope = 'global') {
   }
 }
 
-export default { createVulcanEnv, readVulcanEnv };
+/**
+ * Loads a custom Vulcan configuration file from the current working directory.
+ * @async
+ * @returns {Promise<object|null>} A promise that resolves to the custom Vulcan configuration module if it exists, or null otherwise.
+ * @throws {Error} Throws an error if there are issues importing the configuration file.
+ * @example
+ * loadVulcanConfigFile()
+ *   .then(config => {
+ *     if (config) {
+ *       console.log('Custom configuration loaded:', config);
+ *     } else {
+ *       console.log('No custom configuration found.');
+ *     }
+ *   })
+ *   .catch(error => console.error('Failed to load custom configuration:', error));
+ */
+async function loadVulcanConfigFile() {
+  const buildConfigPath = path.join(process.cwd(), 'vulcan.config.js');
+  let vulcanCustomConfig = null;
+
+  if (fs.existsSync(buildConfigPath)) {
+    const vulcanCustomConfigModule = await import(`file://${buildConfigPath}`);
+    vulcanCustomConfig = vulcanCustomConfigModule.default || {};
+  }
+
+  return vulcanCustomConfig;
+}
+
+export default { createVulcanEnv, readVulcanEnv, loadVulcanConfigFile };


### PR DESCRIPTION
### Description
This PR introduces the possibility of creating a file called "vulcan.config.js" in the project so that it is possible to make build configurations directly in the project without the need to change presets.

It also introduces the _memoryFS_ object for in-memory fs usage (temporary solution):

- injectionDirs: array of strings indicating the directories that contain the files to be injected into memory.
- removePathPrefix: string with the prefix to be removed from the paths mapped for use in fs (e.g. in the case of vtex you need to remove .faststore).

#### To use, simply create a vulcan.config.js file in the root of the project. Example:
![vulcanconfig](https://github.com/aziontech/vulcan/assets/12740219/e79f5fbb-8441-489d-a846-ad8e22d9ccad)
