### PR TITLE
feat: In Memory File System

### DIFF
--- a/lib/build/bundlers/esbuild/index.js
+++ b/lib/build/bundlers/esbuild/index.js
@@ -34,6 +34,17 @@ class Esbuild {
       config.plugins = [NodeModulesPolyfillPlugin(), ...config.plugins];
     }
 
+    // inject content in worker initial code.
+    if (this.builderConfig.contentToInject) {
+      const workerInitContent = this.builderConfig.contentToInject;
+
+      if (config.banner?.js) {
+        config.banner.js = `${config.banner.js} ${workerInitContent}`;
+      } else {
+        config.banner = { js: workerInitContent };
+      }
+    }
+
     try {
       await esbuild.build(config);
     } catch (error) {

--- a/lib/build/bundlers/webpack/index.js
+++ b/lib/build/bundlers/webpack/index.js
@@ -30,6 +30,36 @@ class Webpack {
       config = merge(this.customConfig, config);
     }
 
+    // inject content in worker initial code.
+    if (this.builderConfig.contentToInject) {
+      const workerInitContent = this.builderConfig.contentToInject;
+
+      const bannerPluginIndex = config.plugins.findIndex(
+        (plugin) => plugin instanceof webpack.BannerPlugin,
+      );
+
+      if (bannerPluginIndex !== -1) {
+        const oldContent = config.plugins[bannerPluginIndex].options.banner;
+        const pluginToRemove = config.plugins[bannerPluginIndex];
+        config.plugins = config.plugins.filter(
+          (plugin) => plugin !== pluginToRemove,
+        );
+        config.plugins.push(
+          new webpack.BannerPlugin({
+            banner: `${oldContent} ${workerInitContent}`,
+            raw: true,
+          }),
+        );
+      } else {
+        config.plugins.push(
+          new webpack.BannerPlugin({
+            banner: workerInitContent,
+            raw: true,
+          }),
+        );
+      }
+    }
+
     try {
       const stats = await runWebpack(config);
 

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -19,6 +19,7 @@ import {
   getPackageManager,
   getProjectJsonFile,
   relocateImportsAndRequires,
+  injectFilesInMem,
 } from '#utils';
 import { Messages } from '#constants';
 import { vulcan } from '#env';
@@ -332,6 +333,21 @@ class Dispatcher {
       config.localCustom = this.custom;
 
       const builderSelected = this.builder || config.builder;
+
+      const { injectionDirs, removePathPrefix } = this.memoryFS;
+      if (injectionDirs && injectionDirs.length > 0) {
+        const content = await injectFilesInMem(injectionDirs);
+
+        const prefix =
+          removePathPrefix &&
+          typeof removePathPrefix === 'string' &&
+          removePathPrefix !== ''
+            ? `'${removePathPrefix}'`
+            : `''`;
+
+        config.contentToInject = `globalThis.FS_PATH_PREFIX_TO_REMOVE = ${prefix};\n${content}`;
+      }
+
       let builder;
       switch (builderSelected) {
         case 'webpack':

--- a/lib/build/polyfills/node/fs.js
+++ b/lib/build/polyfills/node/fs.js
@@ -1,0 +1,621 @@
+/* eslint-disable max-classes-per-file */
+import path from 'path-browserify';
+import { Buffer } from 'buffer';
+
+/* eslint-disable */
+
+const MEM_FILES = globalThis.__FILES__;
+
+globalThis.FS_PATHS_CHANGED = false;
+
+/**
+ * fix mapped files paths based on path prefix
+ */
+function fixMappedFilesPaths() {
+  if (
+    !globalThis.FS_PATHS_CHANGED &&
+    globalThis.FS_PATH_PREFIX_TO_REMOVE !== ''
+  ) {
+    Object.keys(MEM_FILES).forEach((e) => {
+      const newKey = e.replace(globalThis.FS_PATH_PREFIX_TO_REMOVE, '');
+      MEM_FILES[newKey] = MEM_FILES[e];
+      delete MEM_FILES[e];
+    });
+  }
+
+  globalThis.FS_PATHS_CHANGED = true;
+}
+
+// ### fs polyfill utils
+/**
+ * Get file object stored in mem
+ * @returns {any} file object
+ */
+function getFile(path) {
+  fixMappedFilesPaths();
+
+  return MEM_FILES[path];
+}
+
+/**
+ * Decode file content to return
+ * @returns {string|Buffer} the file content
+ */
+function getFileContent(file, returnBuffer = true) {
+  const buff = Buffer.from(file.content, 'base64');
+
+  if (returnBuffer) {
+    return buff;
+  } else {
+    return buff.toString('utf8');
+  }
+}
+
+/**
+ * Get available files in worker memory
+ * @returns {string[]} list of mapped files paths
+ */
+function getAvailableFiles() {
+  if (MEM_FILES && typeof MEM_FILES === 'object') return Object.keys(MEM_FILES);
+
+  return [];
+}
+
+/**
+ * Get available dirs based on mapped files
+ * @param {string[]} - files paths
+ * @returns {string[]} - list of available dirs
+ */
+function getAvailableDirs(files) {
+  if (files.length > 0) {
+    const existingDirs = new Set();
+
+    files.forEach((filePath) => {
+      const dirPath = path.dirname(filePath);
+
+      let currentPath = '/';
+      let pathSegments = dirPath.split('/');
+      for (let i = 0; i < pathSegments.length; i++) {
+        currentPath = path.join(currentPath, pathSegments[i]);
+        if (!existingDirs.has(currentPath)) {
+          existingDirs.add(currentPath);
+        }
+      }
+    });
+
+    const dirs = Array.from(existingDirs);
+
+    return dirs;
+  }
+
+  return [];
+}
+
+/**
+ * Get mapped files infos
+ * @returns {object} - object with files, dirs and paths
+ */
+function getFilesInfos() {
+  fixMappedFilesPaths();
+
+  const files = getAvailableFiles();
+  const dirs = getAvailableDirs(files);
+
+  return {
+    files,
+    dirs,
+    paths: [...files, ...dirs],
+  };
+}
+
+/**
+ * Returns a valid path
+ * @returns {string} - path to fix
+ */
+function getValidatedPath(path) {
+  if (path.endsWith('/')) path = path.slice(0, -1);
+  if (!path.startsWith('/')) path = `/${path}`;
+
+  return path;
+}
+
+function generateDefaultStat() {
+  const defaultDate = new Date();
+
+  return {
+    dev: 16777231,
+    mode: 33188,
+    nlink: 1,
+    uid: 503,
+    gid: 20,
+    rdev: 0,
+    blksize: 4096,
+    ino: 99415867,
+    size: 4037,
+    blocks: 8,
+    atimeMs: 1696531597782.944,
+    mtimeMs: 1696531596158.1772,
+    ctimeMs: 1696531596158.1772,
+    birthtimeMs: 1695652120928.4453,
+    atime: defaultDate,
+    mtime: defaultDate,
+    ctime: defaultDate,
+    birthtime: defaultDate,
+  };
+}
+
+// ### fs polyfills
+// code based on node implementations
+
+const UV_FS_SYMLINK_DIR = 1;
+const UV_FS_SYMLINK_JUNCTION = 2;
+const O_RDONLY = 0;
+const O_WRONLY = 1;
+const O_RDWR = 2;
+const UV_DIRENT_UNKNOWN = 0;
+const UV_DIRENT_FILE = 1;
+const UV_DIRENT_DIR = 2;
+const UV_DIRENT_LINK = 3;
+const UV_DIRENT_FIFO = 4;
+const UV_DIRENT_SOCKET = 5;
+const UV_DIRENT_CHAR = 6;
+const UV_DIRENT_BLOCK = 7;
+const S_IFMT = 61440;
+const S_IFREG = 32768;
+const S_IFDIR = 16384;
+const S_IFCHR = 8192;
+const S_IFBLK = 24576;
+const S_IFIFO = 4096;
+const S_IFLNK = 40960;
+const S_IFSOCK = 49152;
+const O_CREAT = 512;
+const O_EXCL = 2048;
+const UV_FS_O_FILEMAP = 0;
+const O_NOCTTY = 131072;
+const O_TRUNC = 1024;
+const O_APPEND = 8;
+const O_DIRECTORY = 1048576;
+const O_NOFOLLOW = 256;
+const O_SYNC = 128;
+const O_DSYNC = 4194304;
+const O_SYMLINK = 2097152;
+const O_NONBLOCK = 4;
+const S_IRWXU = 448;
+const S_IRUSR = 256;
+const S_IWUSR = 128;
+const S_IXUSR = 64;
+const S_IRWXG = 56;
+const S_IRGRP = 32;
+const S_IWGRP = 16;
+const S_IXGRP = 8;
+const S_IRWXO = 7;
+const S_IROTH = 4;
+const S_IWOTH = 2;
+const S_IXOTH = 1;
+const F_OK = 0;
+const R_OK = 4;
+const W_OK = 2;
+const X_OK = 1;
+const UV_FS_COPYFILE_EXCL = 1;
+const COPYFILE_EXCL = 1;
+const UV_FS_COPYFILE_FICLONE = 2;
+const COPYFILE_FICLONE = 2;
+const UV_FS_COPYFILE_FICLONE_FORCE = 4;
+const COPYFILE_FICLONE_FORCE = 4;
+
+const kType = Symbol('type');
+const kStats = Symbol('stats');
+
+class Dirent {
+  constructor(name, type, path) {
+    this.name = name;
+    this.path = path;
+    this[kType] = type;
+  }
+
+  isDirectory() {
+    return this[kType] === UV_DIRENT_DIR;
+  }
+
+  isFile() {
+    return this[kType] === UV_DIRENT_FILE;
+  }
+
+  isBlockDevice() {
+    return this[kType] === UV_DIRENT_BLOCK;
+  }
+
+  isCharacterDevice() {
+    return this[kType] === UV_DIRENT_CHAR;
+  }
+
+  isSymbolicLink() {
+    return this[kType] === UV_DIRENT_LINK;
+  }
+
+  isFIFO() {
+    return this[kType] === UV_DIRENT_FIFO;
+  }
+
+  isSocket() {
+    return this[kType] === UV_DIRENT_SOCKET;
+  }
+}
+
+class DirentFromStats extends Dirent {
+  constructor(name, stats, path) {
+    super(name, null, path);
+    this[kStats] = stats;
+  }
+}
+
+const kEmptyObject = { __proto__: null };
+
+function defaultCloseCallback(err) {
+  if (err != null) throw err;
+}
+
+function maybeCallback(cb) {
+  if (typeof cb !== 'function') {
+    throw new Error('Param is not a function!');
+  }
+
+  return cb;
+}
+
+function assertEncoding(encoding) {
+  if (encoding && !Buffer.isEncoding(encoding)) {
+    throw new Error('Invalid encoding!');
+  }
+}
+
+function getOptions(options, defaultOptions = kEmptyObject) {
+  if (options == null || typeof options === 'function') {
+    return defaultOptions;
+  }
+
+  if (typeof options === 'string') {
+    defaultOptions = { ...defaultOptions };
+    defaultOptions.encoding = options;
+    options = defaultOptions;
+  } else if (typeof options !== 'object') {
+    throw new Error('Invalid options!');
+  }
+
+  if (options.encoding !== 'buffer') assertEncoding(options.encoding);
+
+  if (options.signal !== undefined) {
+    // validateAbortSignal(options.signal, 'options.signal');
+  }
+
+  return options;
+}
+
+/**
+ * Closes the file descriptor.
+ * @param {number} fd
+ * @param {(err?: Error) => any} [callback]
+ * @returns {void}
+ */
+function close(fd, callback = defaultCloseCallback) {
+  setTimeout(() => {
+    // (In-memory implementation doesn't require explicit closing)
+    callback(null);
+  }, 0);
+}
+
+/**
+ * Synchronously closes the file descriptor.
+ * @param {number} fd
+ * @returns {void}
+ */
+function closeSync(fd) {
+  // (In-memory implementation doesn't require explicit closing)
+}
+
+/**
+ * Asynchronously opens a file.
+ * @param {string | Buffer | URL} path
+ * @param {string | number} [flags]
+ * @param {string | number} [mode]
+ * @param {(
+ *   err?: Error,
+ *   fd?: number
+ *   ) => any} callback
+ * @returns {void}
+ */
+function open(path, flags, mode, callback) {
+  // handle function args (code from node)
+  if (arguments.length < 3) {
+    callback = flags;
+    flags = 'r';
+    mode = 0o666;
+  } else if (typeof mode === 'function') {
+    callback = mode;
+    mode = 0o666;
+  } else {
+    mode = '0o666';
+  }
+
+  setTimeout(() => {
+    path = getValidatedPath(path);
+    const file = getFile(path);
+    if (file !== undefined) {
+      const fileDescriptor = Symbol(`File Descriptor for ${path}`);
+
+      callback(null, fileDescriptor);
+    } else {
+      const error = new Error(
+        `ENOENT: no such file or directory, fs.open call for path '${path}'`,
+      );
+      error.code = 'ENOENT';
+
+      callback(error);
+    }
+  }, 0);
+}
+
+/**
+ * Synchronously opens a file.
+ * @param {string | Buffer | URL} path
+ * @param {string | number} [flags]
+ * @param {string | number} [mode]
+ * @returns {number}
+ */
+function openSync(path, flags, mode) {
+  path = getValidatedPath(path);
+  const file = getFile(path);
+  if (file !== undefined) {
+    const fileDescriptor = Symbol(`File Descriptor for ${path}`);
+
+    return fileDescriptor;
+  } else {
+    const error = new Error(
+      `ENOENT: no such file or directory, fs.openSync call for path '${path}'`,
+    );
+    error.code = 'ENOENT';
+
+    throw error;
+  }
+}
+
+/**
+ * Asynchronously gets the stats of a file.
+ * @param {string | Buffer | URL} path
+ * @param {{ bigint?: boolean; }} [options]
+ * @param {(
+ *   err?: Error,
+ *   stats?: any
+ *   ) => any} callback
+ * @returns {void}
+ */
+async function stat(path, options = { bigint: false }, callback) {
+  // handle function args (code from node)
+  if (typeof options === 'function') {
+    callback = options;
+    options = kEmptyObject;
+  }
+
+  path = getValidatedPath(path);
+
+  setTimeout(() => {
+    const filesInfos = getFilesInfos();
+    if (!filesInfos.paths.includes(path)) {
+      const error = new Error(
+        `ENOENT: no such file or directory, fs.stat call for path '${path}'`,
+      );
+      error.code = 'ENOENT';
+      callback(error);
+    }
+
+    const file = getFile(path);
+    const isFile = filesInfos.files.includes(path);
+    const size = isFile ? file.content.length : 0;
+
+    // generate file informations
+    const stats = generateDefaultStat();
+    stats.size = size;
+    stats.isFile = () => isFile;
+    stats.isDirectory = () => !isFile;
+
+    callback(null, stats);
+  }, 0);
+}
+
+/**
+ * Synchronously retrieves the `fs.Stats`
+ * for the `path`.
+ * @param {string | Buffer | URL} path
+ * @param {{
+ *   bigint?: boolean;
+ *   throwIfNoEntry?: boolean;
+ *   }} [options]
+ * @returns {any}
+ */
+function statSync(path, options) {
+  // checks final /
+  path = getValidatedPath(path);
+
+  // Synchronous method to get file information
+  const filesInfos = getFilesInfos();
+  if (!filesInfos.paths.includes(path)) {
+    const error = new Error(
+      `ENOENT: no such file or directory, fs.statSync call for path '${path}'`,
+    );
+    error.code = 'ENOENT';
+    throw error;
+  }
+
+  const file = getFile(path);
+
+  const isFile = filesInfos.files.includes(path);
+  const size = isFile ? file.content.length : 0;
+
+  // generate file informations
+  const stats = generateDefaultStat();
+  stats.size = size;
+  stats.isFile = () => isFile;
+  stats.isDirectory = () => !isFile;
+
+  return stats;
+}
+
+/**
+ * Asynchronously reads the entire contents of a file.
+ * @param {string | Buffer | URL | number} path
+ * @param {{
+ *   encoding?: string | null;
+ *   flag?: string;
+ *   signal?: AbortSignal;
+ *   } | string} [options]
+ * @param {(
+ *   err?: Error,
+ *   data?: string | Buffer
+ *   ) => any} callback
+ * @returns {void}
+ */
+function readFile(path, options, callback) {
+  // handle function args
+  if (typeof options === 'function') {
+    callback = options;
+    options = { ...kEmptyObject };
+  }
+  callback = maybeCallback(callback || options);
+  options = getOptions(options, { flag: 'r' });
+  path = getValidatedPath(path);
+
+  setTimeout(() => {
+    const file = getFile(path);
+    if (file !== undefined) {
+      let content;
+      if (options?.encoding === 'utf-8') {
+        content = getFileContent(file, false);
+      } else {
+        content = getFileContent(file, true);
+      }
+      callback(null, content);
+    } else {
+      const error = new Error(
+        `ENOENT: no such file or directory, fs.readFile call for path '${path}'`,
+      );
+      error.code = 'ENOENT';
+      callback(error);
+    }
+  }, 0);
+}
+
+/**
+ * Synchronously reads the entire contents of a file.
+ * @param {string | Buffer | URL | number} path
+ * @param {{
+ *   encoding?: string | null;
+ *   flag?: string;
+ *   }} [options]
+ * @returns {string | Buffer}
+ */
+function readFileSync(path, options) {
+  path = getValidatedPath(path);
+  options = getOptions(options, { flag: 'r' });
+
+  const file = getFile(path);
+  if (file !== undefined) {
+    let content;
+    if (options?.encoding === 'utf-8') {
+      content = getFileContent(file, false);
+    } else {
+      content = getFileContent(file, true);
+    }
+    return content;
+  } else {
+    const error = new Error(
+      `ENOENT: no such file or directory, fs.readFileSync call for path '${path}'`,
+    );
+    error.code = 'ENOENT';
+    throw error;
+  }
+}
+
+/**
+ * Synchronously reads the contents of a directory.
+ * @param {string | Buffer | URL} path
+ * @param {string | {
+ *   encoding?: string;
+ *   withFileTypes?: boolean;
+ *   recursive?: boolean;
+ *   }} [options]
+ * @returns {string | Buffer[] | Dirent[]}
+ */
+function readdirSync(path, options) {
+  path = getValidatedPath(path);
+
+  const filesInfos = getFilesInfos();
+  const stats = statSync(path);
+
+  if (!stats.isDirectory()) {
+    const error = new Error(
+      `ENOTDIR: not a directory, scandir - fs.readdirSync call for path '${path}'`,
+    );
+    error.code = 'ENOTDIR';
+    throw error;
+  }
+
+  let result = [];
+  const matchedElements = filesInfos.paths.filter(
+    (dir) => dir.startsWith(path) && path !== dir,
+  );
+  const elementsInDir = [
+    ...new Set(
+      matchedElements.map(
+        (element) => element.replace(`${path}/`, '').split('/')[0],
+      ),
+    ),
+  ];
+
+  // generate the list of elements in dir (strings or Dirents)
+  if (options.withFileTypes) {
+    result = elementsInDir.map((element) => {
+      const name = element;
+      const isFile = filesInfos.files.includes(`${path}/${element}`);
+      const type = isFile ? UV_DIRENT_FILE : UV_DIRENT_DIR;
+      return new Dirent(name, type, `${path}/${element}`);
+    });
+  } else {
+    result = elementsInDir;
+  }
+
+  return result;
+}
+
+const promises = { readFile, stat };
+
+const fs = {
+  close,
+  closeSync,
+  open,
+  openSync,
+  stat,
+  statSync,
+  lstatSync: statSync,
+  readFile,
+  readFileSync,
+  readdirSync,
+  promises,
+};
+
+export default fs;
+
+export {
+  close,
+  closeSync,
+  open,
+  openSync,
+  stat,
+  statSync,
+  statSync as lstatSync,
+  readFile,
+  readFileSync,
+  readdirSync,
+  promises,
+};
+
+/* eslint-enable */

--- a/lib/build/polyfills/node/globals/process.js
+++ b/lib/build/polyfills/node/globals/process.js
@@ -1,0 +1,238 @@
+/* eslint-disable prefer-rest-params */
+/* eslint-disable no-use-before-define */
+/* eslint-disable no-shadow */
+/* eslint-disable func-names */
+
+/*
+ * Copyright Azion
+ * Licensed under the MIT license. See LICENSE file for details.
+ *
+ * Portions of this file Copyright Roman Shtylman, licensed under the MIT license.
+ * npmjs: https://www.npmjs.com/package/process
+ * repo: https://github.com/defunctzombie/node-process
+ */
+
+// shim for using process in browser
+const process = {};
+
+// cached from whatever global is present so that test runners that stub it
+// don't break things.  But we need to wrap it in a try catch in case it is
+// wrapped in strict mode code which doesn't define any globals.  It's inside a
+// function because try/catches deoptimize in certain engines.
+
+let cachedSetTimeout;
+let cachedClearTimeout;
+
+/**
+ *
+ */
+function defaultSetTimout() {
+  throw new Error('setTimeout has not been defined');
+}
+/**
+ *
+ */
+function defaultClearTimeout() {
+  throw new Error('clearTimeout has not been defined');
+}
+(function () {
+  try {
+    if (typeof setTimeout === 'function') {
+      cachedSetTimeout = setTimeout;
+    } else {
+      cachedSetTimeout = defaultSetTimout;
+    }
+  } catch (e) {
+    cachedSetTimeout = defaultSetTimout;
+  }
+  try {
+    if (typeof clearTimeout === 'function') {
+      cachedClearTimeout = clearTimeout;
+    } else {
+      cachedClearTimeout = defaultClearTimeout;
+    }
+  } catch (e) {
+    cachedClearTimeout = defaultClearTimeout;
+  }
+})();
+/**
+/**
+ * @param {Function} fun - The function to be executed.
+ * @returns {void} Returns nothing.
+ */
+function runTimeout(fun) {
+  if (cachedSetTimeout === setTimeout) {
+    // normal enviroments in sane situations
+    return setTimeout(fun, 0);
+  }
+  // if setTimeout wasn't available but was latter defined
+  if (
+    (cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) &&
+    setTimeout
+  ) {
+    cachedSetTimeout = setTimeout;
+    return setTimeout(fun, 0);
+  }
+  try {
+    // when when somebody has screwed with setTimeout but no I.E. maddness
+    return cachedSetTimeout(fun, 0);
+  } catch (e) {
+    try {
+      // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
+      return cachedSetTimeout.call(null, fun, 0);
+    } catch (e) {
+      // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
+      return cachedSetTimeout.call(this, fun, 0);
+    }
+  }
+}
+/**
+/**
+ * @param {any} marker - A marker that was returned from calling setTimeout().
+ * @returns {void}
+ */
+function runClearTimeout(marker) {
+  if (cachedClearTimeout === clearTimeout) {
+    // normal enviroments in sane situations
+    return clearTimeout(marker);
+  }
+  // if clearTimeout wasn't available but was latter defined
+  if (
+    (cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) &&
+    clearTimeout
+  ) {
+    cachedClearTimeout = clearTimeout;
+    return clearTimeout(marker);
+  }
+  try {
+    // when when somebody has screwed with setTimeout but no I.E. maddness
+    return cachedClearTimeout(marker);
+  } catch (e) {
+    try {
+      // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
+      return cachedClearTimeout.call(null, marker);
+    } catch (e) {
+      // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
+      // Some versions of I.E. have different rules for clearTimeout vs setTimeout
+      return cachedClearTimeout.call(this, marker);
+    }
+  }
+}
+let queue = [];
+let draining = false;
+let currentQueue;
+let queueIndex = -1;
+
+/**
+ *
+ */
+function drainQueue() {
+  if (draining) {
+    return;
+  }
+  const timeout = runTimeout(cleanUpNextTick);
+  draining = true;
+
+  let len = queue.length;
+  while (len) {
+    currentQueue = queue;
+    queue = [];
+    while (++queueIndex < len) {
+      if (currentQueue) {
+        currentQueue[queueIndex].run();
+      }
+    }
+    queueIndex = -1;
+    len = queue.length;
+  }
+  currentQueue = null;
+  draining = false;
+  runClearTimeout(timeout);
+}
+
+/**
+ *
+ */
+function cleanUpNextTick() {
+  if (!draining || !currentQueue) {
+    return;
+  }
+  draining = false;
+  if (currentQueue.length) {
+    queue = currentQueue.concat(queue);
+  } else {
+    queueIndex = -1;
+  }
+  if (queue.length) {
+    drainQueue();
+  }
+}
+
+/**
+ *
+ */
+
+process.nextTick = function (fun) {
+  const args = new Array(arguments.length - 1);
+  if (arguments.length > 1) {
+    for (let i = 1; i < arguments.length; i++) {
+      args[i - 1] = arguments[i];
+    }
+  }
+  queue.push(new Item(fun, args));
+  if (queue.length === 1 && !draining) {
+    runTimeout(drainQueue);
+  }
+};
+
+// v8 likes predictible objects
+/**
+ * @param {Function} fun - return a item
+ * @param {Array} array - return a array
+ */
+function Item(fun, array) {
+  this.fun = fun;
+  this.array = array;
+}
+Item.prototype.run = function () {
+  this.fun.apply(null, this.array);
+};
+process.title = 'browser';
+process.browser = true;
+process.env = {};
+process.argv = [];
+process.version = ''; // empty string to avoid regexp issues
+process.versions = { node: '18.3.1' }; // fake version
+
+/**
+ *
+ */
+function noop() {}
+
+process.on = noop;
+process.addListener = noop;
+process.once = noop;
+process.off = noop;
+process.removeListener = noop;
+process.removeAllListeners = noop;
+process.emit = noop;
+process.prependListener = noop;
+process.prependOnceListener = noop;
+
+process.listeners = function () {
+  return [];
+};
+
+process.binding = function () {
+  throw new Error('process.binding is not supported');
+};
+
+process.cwd = function () {
+  return '/';
+};
+process.chdir = function () {
+  throw new Error('process.chdir is not supported');
+};
+process.umask = function () {
+  return 0;
+};

--- a/lib/build/polyfills/node/module.js
+++ b/lib/build/polyfills/node/module.js
@@ -1,0 +1,138 @@
+/* eslint-disable */
+
+function createRequire(...args) {
+  /* EMPTY */
+}
+
+function unimplemented() {
+  throw new Error('Node.js module module is not supported by Cells');
+}
+
+var builtinModules = [
+  '_http_agent',
+  '_http_client',
+  '_http_common',
+  '_http_incoming',
+  '_http_outgoing',
+  '_http_server',
+  '_stream_duplex',
+  '_stream_passthrough',
+  '_stream_readable',
+  '_stream_transform',
+  '_stream_wrap',
+  '_stream_writable',
+  '_tls_common',
+  '_tls_wrap',
+  'assert',
+  'assert/strict',
+  'async_hooks',
+  'buffer',
+  'child_process',
+  'cluster',
+  'console',
+  'constants',
+  'crypto',
+  'dgram',
+  'diagnostics_channel',
+  'dns',
+  'dns/promises',
+  'domain',
+  'events',
+  'fs',
+  'fs/promises',
+  'http',
+  'http2',
+  'https',
+  'inspector',
+  'module',
+  'net',
+  'os',
+  'path',
+  'path/posix',
+  'path/win32',
+  'perf_hooks',
+  'process',
+  'punycode',
+  'querystring',
+  'readline',
+  'repl',
+  'stream',
+  'stream/consumers',
+  'stream/promises',
+  'stream/web',
+  'string_decoder',
+  'sys',
+  'timers',
+  'timers/promises',
+  'tls',
+  'trace_events',
+  'tty',
+  'url',
+  'util',
+  'util/types',
+  'v8',
+  'vm',
+  'worker_threads',
+  'zlib',
+];
+
+function _load(...args) {
+  /* EMPTY */
+}
+
+function _nodeModulePaths(...args) {
+  /* EMPTY */
+}
+
+function _resolveFilename(...args) {
+  /* EMPTY */
+}
+
+export default {
+  builtinModules: builtinModules,
+  _cache: null,
+  _pathCache: null,
+  _extensions: null,
+  globalPaths: null,
+  _debug: unimplemented,
+  _findPath: unimplemented,
+  _nodeModulePaths: _nodeModulePaths,
+  _resolveLookupPaths: unimplemented,
+  _load: _load,
+  _resolveFilename: _resolveFilename,
+  createRequireFromPath: unimplemented,
+  createRequire: createRequire,
+  _initPaths: unimplemented,
+  _preloadModules: unimplemented,
+  syncBuiltinESMExports: unimplemented,
+  Module: unimplemented,
+  runMain: unimplemented,
+  findSourceMap: unimplemented,
+  SourceMap: unimplemented,
+};
+
+export var _cache = null,
+  _pathCache = null,
+  _extensions = null,
+  globalPaths = null;
+
+export {
+  builtinModules,
+  unimplemented as _debug,
+  unimplemented as _findPath,
+  unimplemented as _nodeModulePaths,
+  unimplemented as _resolveLookupPaths,
+  unimplemented as _load,
+  unimplemented as _resolveFilename,
+  createRequire as createRequireFromPath,
+  createRequire as createRequire,
+  unimplemented as _initPaths,
+  unimplemented as _preloadModules,
+  unimplemented as syncBuiltinESMExports,
+  unimplemented as Module,
+  unimplemented as runMain,
+  unimplemented as findSourceMap,
+  unimplemented as SourceMap,
+};
+
+/* eslint-enable */

--- a/lib/presets/custom/next/compute/config.js
+++ b/lib/presets/custom/next/compute/config.js
@@ -7,7 +7,8 @@ import { getAbsoluteLibDirPath, generateWebpackBanner } from '#utils';
 
 const require = createRequire(import.meta.url);
 const libDirPath = getAbsoluteLibDirPath();
-const nodePolyfillsPath = `${libDirPath}/build/polyfills/node`;
+const polyfillsPath = `${libDirPath}/build/polyfills`;
+const nodePolyfillsPath = `${polyfillsPath}/node`;
 const nextNodePresetPath = `${libDirPath}/presets/custom/next/compute/node`;
 
 /**
@@ -41,12 +42,12 @@ const config = {
       // or core nodejs modules needed for your application.
       new webpack.ProvidePlugin({
         Buffer: ['buffer', 'Buffer'],
-        process: 'process',
       }),
       new webpack.BannerPlugin({
         banner: generateWebpackBanner([
           `${nodePolyfillsPath}/globals/navigator.js`,
           `${nodePolyfillsPath}/globals/performance.js`,
+          `${nodePolyfillsPath}/globals/process.js`,
         ]),
         raw: true,
       }),
@@ -61,28 +62,26 @@ const config = {
     resolve: {
       mainFields: ['browser', 'main', 'module'],
       alias: {
-        'next/dist/compiled/raw-body': require.resolve('raw-body'),
         util: require.resolve('util/'),
       },
       fallback: {
         async_hooks: false,
         tls: false,
         net: false,
-        fs: false,
         http: require.resolve('stream-http'),
         buffer: require.resolve('buffer/'),
         crypto: require.resolve('crypto-browserify/'),
         events: require.resolve('events/'),
         os: require.resolve('os-browserify/browser'),
         path: require.resolve('path-browserify'),
-        process: require.resolve('process/browser'),
         querystring: require.resolve('querystring-es3'),
         stream: require.resolve('stream-browserify'),
         url: require.resolve('url/'),
-        util: require.resolve('util/'),
         zlib: require.resolve('browserify-zlib'),
         dns: `${nodePolyfillsPath}/dns.js`,
         http2: `${nodePolyfillsPath}/http2.js`,
+        module: `${nodePolyfillsPath}/module.js`,
+        fs: `${nodePolyfillsPath}/fs.js`,
         'next/dist/compiled/etag': `${nextNodePresetPath}/custom-server/12.3.1/util/etag.js`,
         '@fastly/http-compute-js': require.resolve('@fastly/http-compute-js'),
         accepts: require.resolve('accepts'),

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -17,6 +17,7 @@ import getUrlFromResource from './getUrlFromResource/index.js';
 import generateWebpackBanner from './generateWebpackBanner/index.js';
 import relocateImportsAndRequires from './relocateImportsAndRequires/index.js';
 import getExportedFunctionBody from './getExportedFunctionBody/index.js';
+import injectFilesInMem from './injectFilesInMem/index.js';
 
 export {
   copyDirectory,
@@ -38,4 +39,5 @@ export {
   VercelUtils,
   generateWebpackBanner,
   relocateImportsAndRequires,
+  injectFilesInMem,
 };

--- a/lib/utils/injectFilesInMem/index.js
+++ b/lib/utils/injectFilesInMem/index.js
@@ -1,0 +1,3 @@
+import injectFilesInMem from './injectFilesInMem.utils.js';
+
+export default injectFilesInMem;

--- a/lib/utils/injectFilesInMem/injectFilesInMem.utils.js
+++ b/lib/utils/injectFilesInMem/injectFilesInMem.utils.js
@@ -1,0 +1,51 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * Reads files from a dir (recursively), mount an object with the files contents
+ * and generates a code to be used in the worker build process.
+ * This files mapping will be available in globalThis.\_\_FILES\_\_(worker memory).
+ * You can use fs module to retrieve this files.
+ * @param {string[]} dirs - paths of dirs to inject
+ * @returns {string} - the code to be injected in bundle process.
+ */
+async function injectFilesInMem(dirs) {
+  const result = {};
+
+  /**
+   * Read content from files and save in the result
+   * @param {string} dir - dir to read files;
+   */
+  async function readFilesRecursively(dir) {
+    const files = await fs.readdir(dir);
+
+    await Promise.all(
+      files.map(async (file) => {
+        const filePath = path.join(dir, file);
+        const stats = await fs.stat(filePath);
+
+        if (stats.isDirectory()) {
+          await readFilesRecursively(filePath);
+        } else if (stats.isFile()) {
+          const bufferContent = await fs.readFile(filePath);
+          let key = filePath;
+          if (!filePath.startsWith('/')) key = `/${filePath}`;
+          const bufferObject = JSON.stringify(bufferContent.toString('base64'));
+          result[key] = { content: bufferObject };
+        }
+      }),
+    );
+  }
+
+  await Promise.all(
+    dirs.map(async (dir) => {
+      await readFilesRecursively(dir);
+    }),
+  );
+
+  const codeToInject = `globalThis.__FILES__=${JSON.stringify(result)};`;
+
+  return codeToInject;
+}
+
+export default injectFilesInMem;


### PR DESCRIPTION
This PR adds in memory file system feature.

### How it works
During the build process (based on config) vulcan will read all specified directories and map the files. After this the build process will inject this mapping to a global var. 

The fs node module will get infos from this in memory mapping. 

### How to test
You can test this in a next compute project.
In your project root create `vulcan.config.js` file to use this feature. The file must be like this:
```
module.exports = {
    memoryFS: {
        injectionDirs: ['.faststore/@generated/graphql'],
        removePathPrefix: '.faststore/',
    }
};
```
After this, run build and dev commands.
```
vulcan build --preset next --mode compute
vulcan dev
```