### PR TITLE
E2E tests initial structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ jsdoc
 vulcan.env
 .vulcan
 wrangler.toml
+.initialized.keep

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,5 @@ examples
 .prettierrc.json
 .releaserc
 jest.config.js
+tests
+docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  verdaccio:
+    image: verdaccio/verdaccio
+    hostname: 'verdaccio'
+    container_name: 'verdaccio'
+    environment:
+      - VERDACCIO_PORT=4873
+    ports:
+      - '4873:4873'
+    volumes:
+      - './verdaccio/config:/verdaccio/conf'
+      - './verdaccio/plugins:/verdaccio/plugins'
+
+  test:
+    image: node:18-alpine3.17
+    hostname: 'test'
+    container_name: 'test'
+    depends_on:
+      - verdaccio
+    ports:
+      - '3000:3000'
+    volumes:
+      - ./:/vulcan/
+    working_dir: /
+    command: sh /vulcan/tests/scripts/setup-e2e-env.sh
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,5 +24,4 @@ services:
     volumes:
       - ./:/vulcan/
     working_dir: /
-    command: sh /vulcan/tests/scripts/setup-e2e-env.sh
     tty: true

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "e2e:destroy": "tests/scripts/destroy-e2e-env.sh",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:e2e": "yarn e2e:start && sudo jest tests/e2e/ && yarn e2e:stop"
+    "test:e2e": "yarn e2e:start && jest tests/e2e/ && yarn e2e:stop"
   },
   "author": "aziontech",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
     "jest": "^29.7.0",
     "jsdoc": "^4.0.2",
     "mock-fs": "^5.2.0",
-    "prettier": "^3.0.3"
+    "prettier": "^3.0.3",
+    "supertest": "^6.3.3"
   },
   "resolutions": {
     "@babel/types": "7.22.17"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "e2e:destroy": "tests/scripts/destroy-e2e-env.sh",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:e2e": "yarn e2e:start && jest tests/e2e/ && yarn e2e:stop"
+    "test:e2e": "yarn e2e:start && sudo jest tests/e2e/ && yarn e2e:stop"
   },
   "author": "aziontech",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
     "lint:fix": "eslint --fix .",
     "format": "prettier --write .",
     "task:docs": "jsdoc --configure jsdoc.json --verbose",
+    "e2e:start": "tests/scripts/start-e2e-env.sh",
+    "e2e:stop": "tests/scripts/stop-e2e-env.sh",
+    "e2e:destroy": "tests/scripts/destroy-e2e-env.sh",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:e2e": "yarn e2e:start && jest tests/e2e/ && yarn e2e:stop"
   },
   "author": "aziontech",
   "contributors": [

--- a/tests/e2e/astro-static.test.js
+++ b/tests/e2e/astro-static.test.js
@@ -1,0 +1,51 @@
+/* eslint-disable jest/expect-expect */
+import supertest from 'supertest';
+
+import projectInitializer from '../utils/project-initializer.js';
+import projectStop from '../utils/project-stop.js';
+
+// 1 min timeout
+const TIMEOUT = 1 * 60 * 1000;
+
+describe('E2E - astro-static project', () => {
+  const examplePath = '/examples/astro-static/';
+  let request;
+
+  beforeAll(async () => {
+    request = supertest('http://localhost:3000');
+
+    await projectInitializer(examplePath, 'astro', 'deliver');
+  }, TIMEOUT);
+
+  afterAll(async () => {
+    await projectStop();
+  }, TIMEOUT);
+
+  test('Should render home page in "/" route', async () => {
+    const resp = await request
+      .get('/')
+      .expect(200)
+      .expect('Content-Type', /html/);
+
+    expect(resp.text).toMatch('To get started, open the directory');
+    expect(resp.text).toMatch(
+      'Learn how Astro works and explore the official API docs.',
+    );
+  });
+
+  test('Should render edge page in "/edge" route', async () => {
+    const resp = await request
+      .get('/edge')
+      .expect(200)
+      .expect('Content-Type', /html/);
+
+    expect(resp.text).toMatch('Running in Edge.');
+  });
+
+  test('Should return correct asset', async () => {
+    await request
+      .get('/favicon.svg')
+      .expect(200)
+      .expect('Content-Type', /image\/svg/);
+  });
+});

--- a/tests/scripts/destroy-e2e-env.sh
+++ b/tests/scripts/destroy-e2e-env.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose down && rm .initialized.keep

--- a/tests/scripts/setup-e2e-env.sh
+++ b/tests/scripts/setup-e2e-env.sh
@@ -23,6 +23,8 @@ SENTINEL_FILE="/vulcan/.initialized.keep"
 # TODO: improve this init check
 if test -f $SENTINEL_FILE; then
     log_with_color "Container already initialized!" $CYAN
+    log_with_color "* Vulcan version:" $GREEN
+    npx --yes --registry=http://verdaccio:4873 edge-functions@latest --version
 else
     log_with_color "Container NOT initialized! Initializing container ..." $YELLOW
 
@@ -42,7 +44,8 @@ else
     log_with_color "* Publish vulcan in verdaccio" $GREEN
     npm publish --registry http://verdaccio:4873
     npm info edge-functions --json --registry http://verdaccio:4873
-    npx --yes edge-functions@latest --help http://verdaccio:4873
+    log_with_color "* Vulcan version:" $GREEN
+    npx --yes --registry=http://verdaccio:4873 edge-functions@latest --version
 
     cd /
 

--- a/tests/scripts/setup-e2e-env.sh
+++ b/tests/scripts/setup-e2e-env.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# color codes
+RED=31
+GREEN=32
+YELLOW=33
+BLUE=34
+MAGENTA=35
+CYAN=36
+DEFAULT=0
+
+log_with_color() {
+    local message="$1"
+    local color_code="$2"
+    echo -e "\e[${color_code}m${message}\e[0m"
+}
+
+#  isolate examples
+log_with_color "* STARTING ..." $GREEN
+
+SENTINEL_FILE="/vulcan/.initialized.keep"
+
+echo "MY_SENTINEL FILE: ${SENTINEL_FILE}"
+
+# TODO: improve this init check
+if test -f $SENTINEL_FILE; then
+    log_with_color "Container already initialized!" $CYAN
+else
+    log_with_color "Container NOT initialized! Initializing container ..." $YELLOW
+
+    # log_with_color "* Isolate examples" $GREEN
+    cp -r /vulcan/examples/ /examples/
+
+    # install vulcan locally
+    log_with_color "* Install vulcan" $GREEN
+    cd vulcan
+    yarn
+
+    # login in verdaccio registry
+    log_with_color "* Login in verdaccio" $GREEN
+    npx --yes npm-cli-login -u test -p 1234 -e test@domain.test -r http://verdaccio:4873
+
+    # publish vulcan in verdaccio
+    log_with_color "* Publish vulcan in verdaccio" $GREEN
+    npm publish --registry http://verdaccio:4873
+    npm info edge-functions --json --registry http://verdaccio:4873
+    npx --yes edge-functions@latest --help http://verdaccio:4873
+
+    cd /
+
+    echo "OK" > "$SENTINEL_FILE"
+
+    log_with_color "* DONE!" $GREEN
+fi
+
+# keep the container running
+tail -f /dev/null

--- a/tests/scripts/setup-e2e-env.sh
+++ b/tests/scripts/setup-e2e-env.sh
@@ -20,8 +20,6 @@ log_with_color "* STARTING ..." $GREEN
 
 SENTINEL_FILE="/vulcan/.initialized.keep"
 
-echo "MY_SENTINEL FILE: ${SENTINEL_FILE}"
-
 # TODO: improve this init check
 if test -f $SENTINEL_FILE; then
     log_with_color "Container already initialized!" $CYAN
@@ -52,6 +50,3 @@ else
 
     log_with_color "* DONE!" $GREEN
 fi
-
-# keep the container running
-tail -f /dev/null

--- a/tests/scripts/start-e2e-env.sh
+++ b/tests/scripts/start-e2e-env.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker-compose up -d && \
+    sleep 3 && \
+    docker-compose exec test sh /vulcan/tests/scripts/setup-e2e-env.sh

--- a/tests/scripts/stop-e2e-env.sh
+++ b/tests/scripts/stop-e2e-env.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose stop

--- a/tests/utils/project-initializer.js
+++ b/tests/utils/project-initializer.js
@@ -1,0 +1,42 @@
+import { exec } from '#utils';
+
+/**
+ * Sleep n seconds
+ * @param {number} seconds - time to sleep
+ * @returns {any} - Resolved promise after timeout
+ */
+function sleep(seconds) {
+  // eslint-disable-next-line no-promise-executor-return
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+}
+
+/**
+ * Run actions to build and run project in docker container
+ * @param {string} examplePath - project path in container
+ * @param {string} preset - vulcan preset to build
+ * @param {string} mode - vulcan preset mode to build
+ */
+async function projectInitializer(examplePath, preset, mode) {
+  const dockerCmd = `docker exec -w ${examplePath} test`;
+  const dockerBkgCmd = dockerCmd.replace('-w', '-d -w');
+  const vulcanCmd =
+    'npx --yes --registry=http://verdaccio:4873 edge-functions@latest';
+
+  // install project dependencies
+  await exec(`${dockerCmd} yarn`, 'E2E test');
+
+  // run vulcan build
+  await exec(
+    `${dockerCmd} ${vulcanCmd} build --preset ${preset} --mode ${mode}`,
+    'E2E test',
+  );
+
+  // run vulcan in background
+  await exec(`${dockerBkgCmd} ${vulcanCmd} dev`, 'E2E test');
+
+  // wait vulcan server to start
+  // TODO: improve this server init waiting
+  await sleep(2);
+}
+
+export default projectInitializer;

--- a/tests/utils/project-stop.js
+++ b/tests/utils/project-stop.js
@@ -1,0 +1,11 @@
+import { exec } from '#utils';
+
+/**
+ * Stop vulcan server in test container
+ */
+async function projectStop() {
+  // stop server
+  await exec(`docker exec test pkill -9 -f dev`);
+}
+
+export default projectStop;

--- a/verdaccio/config/config.yaml
+++ b/verdaccio/config/config.yaml
@@ -1,0 +1,50 @@
+web:
+  title: Azion
+
+# path to a directory with all packages
+storage: /verdaccio/storage
+
+auth:
+  htpasswd:
+    file: /verdaccio/storage/htpasswd
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+packages:
+  '@*/*':
+    # scoped packages
+    access: $all
+    publish: $all
+    proxy: npmjs
+
+  'edge-functions':
+    access: $all
+    publish: $all
+    unpublish: $all
+
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    #
+    # you can specify usernames/groupnames (depending on your auth plugin)
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+
+    # allow all known users to publish packages
+    # (anyone can register by default, remember?)
+    publish: $all
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+
+# To use `npm audit` uncomment the following section
+middlewares:
+  audit:
+    enabled: true
+
+# log settings
+log:
+  - { type: stdout, format: pretty, level: trace }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3456,7 +3456,7 @@ arrify@^2.0.1:
   resolved "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asap@^2.0.3:
+asap@^2.0.0, asap@^2.0.3:
   version "2.0.6"
   resolved "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
@@ -4480,7 +4480,7 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
-component-emitter@^1.2.1:
+component-emitter@^1.2.1, component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -4596,6 +4596,11 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookiejar@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
+  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -5018,6 +5023,14 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+dezalgo@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
+  integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
+  dependencies:
+    asap "^2.0.0"
+    wrappy "1"
 
 diff-sequences@^29.6.3:
   version "29.6.3"
@@ -5932,6 +5945,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fastest-levenshtein@^1.0.16:
   version "1.0.16"
   resolved "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz"
@@ -6177,6 +6195,16 @@ form-data@^4.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+formidable@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.1.2.tgz#fa973a2bec150e4ce7cac15589d7a25fc30ebd89"
+  integrity sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==
+  dependencies:
+    dezalgo "^1.0.4"
+    hexoid "^1.0.0"
+    once "^1.4.0"
+    qs "^6.11.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -6861,6 +6889,11 @@ hexo@^7.0.0-rc2:
     tildify "^2.0.0"
     titlecase "^1.1.3"
     warehouse "^5.0.0"
+
+hexoid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
+  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
 highlight.js@^11.0.1, highlight.js@^11.6.0:
   version "11.8.0"
@@ -8944,7 +8977,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
@@ -9005,6 +9038,11 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mime@^3.0.0:
   version "3.0.0"
@@ -10504,7 +10542,7 @@ qs@6.11.0:
   dependencies:
     side-channel "^1.0.4"
 
-qs@^6.11.2:
+qs@^6.11.0, qs@^6.11.2:
   version "6.11.2"
   resolved "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz"
   integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
@@ -11156,7 +11194,7 @@ semver-regex@^4.0.5:
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@7.5.4, semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.1, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4:
+semver@7.5.4, semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.1, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
@@ -11678,16 +11716,9 @@ string.prototype.trimstart@^1.0.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-string_decoder@^1.1.1:
+string_decoder@^1.1.1, string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
-string_decoder@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
@@ -11784,6 +11815,30 @@ subscriptions-transport-ws@^0.11.0:
     iterall "^1.2.1"
     symbol-observable "^1.0.4"
     ws "^5.2.0 || ^6.0.0 || ^7.0.0"
+
+superagent@^8.0.5:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-8.1.2.tgz#03cb7da3ec8b32472c9d20f6c2a57c7f3765f30b"
+  integrity sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.4"
+    debug "^4.3.4"
+    fast-safe-stringify "^2.1.1"
+    form-data "^4.0.0"
+    formidable "^2.1.2"
+    methods "^1.1.2"
+    mime "2.6.0"
+    qs "^6.11.0"
+    semver "^7.3.8"
+
+supertest@^6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.3.3.tgz#42f4da199fee656106fd422c094cf6c9578141db"
+  integrity sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^8.0.5"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
Create initial structure to e2e tests.

This PR includes:
- Create docker env with:
  - A node container to simulate vulcan build, publish and use (azion cli like) in a clean env;
  - A verdaccio container to simulate the npmjs registry.
- Astro project example e2e tests (index route, edge route );
- scripts to help in e2e env management;

### How to test:
run in terminal 
```
yarn test:e2e
```