### PR TITLE
feat: generate manifest (initial structure)

### DIFF
--- a/lib/presets/custom/astro/deliver/prebuild.js
+++ b/lib/presets/custom/astro/deliver/prebuild.js
@@ -1,5 +1,10 @@
 import { rm, readFile } from 'fs/promises';
-import { exec, getPackageManager, copyDirectory } from '#utils';
+import {
+  exec,
+  getPackageManager,
+  copyDirectory,
+  generateManifest,
+} from '#utils';
 
 const packageManager = await getPackageManager();
 
@@ -25,6 +30,7 @@ async function prebuild() {
 
   // move files to vulcan default path
   copyDirectory(outDir, newOutDir);
+  generateManifest('*', '*', 'deliver');
   rm(outDir, { recursive: true, force: true });
 }
 

--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -1,0 +1,30 @@
+import { join } from 'path';
+import { writeFileSync } from 'fs';
+import { Utils } from '#namespaces';
+
+/**
+ * @function
+ * @memberof Utils
+ * @description Generates manifest object and writes it to a file.
+ * @param {string} route - the route to be used,  or all represented by '*'
+ * @param {string} filePath - the file path for the route, or all represented by '*'
+ * @param {string} mode - The mode of the operation, either 'compute', 'deliver', or both represented by '*'.
+ */
+function generateManifest(route, filePath, mode) {
+  const manifestPath = join(process.cwd(), '.edge/manifest.json');
+  const manifest = {};
+
+  // Check the mode and add the route to the manifest appropriately.
+  if (mode === 'compute' || mode === 'deliver' || mode === '*') {
+    manifest[mode] = {};
+    manifest[mode][route] = filePath;
+  } else {
+    throw new Error('Invalid mode. Must be "compute", "deliver", or "*".');
+  }
+
+  // Write the new manifest back to the file.
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+  console.log(`New manifest created with ${mode} information.`);
+}
+
+export default generateManifest;

--- a/lib/utils/generateManifest/index.js
+++ b/lib/utils/generateManifest/index.js
@@ -1,0 +1,3 @@
+import generateManifest from './generateManifest.utils.js';
+
+export default generateManifest;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -18,6 +18,7 @@ import generateWebpackBanner from './generateWebpackBanner/index.js';
 import relocateImportsAndRequires from './relocateImportsAndRequires/index.js';
 import getExportedFunctionBody from './getExportedFunctionBody/index.js';
 import injectFilesInMem from './injectFilesInMem/index.js';
+import generateManifest from './generateManifest/index.js';
 
 export {
   copyDirectory,
@@ -40,4 +41,5 @@ export {
   generateWebpackBanner,
   relocateImportsAndRequires,
   injectFilesInMem,
+  generateManifest,
 };


### PR DESCRIPTION
#### This pr introduces the function (#utils) initial version 'generateManifest' to generate the manifest of routes that indicate what is static (deliver) and what is computed on the server (compute).

The function must receive 3 arguments:

 * @param {string} route - the route to be used,  or all represented by '*'
 * @param {string} filePath - the file path for the route, or all represented by '*'
 * @param {string} mode - The mode of the operation, either 'compute', 'deliver', or both represented by '*'.
 */
