### PR TITLE
fix: loop in fs polyfill when readdirSync and path /

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 examples/*
 jsdoc/*
+CODEOWNERS

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ jsdoc/*
 yarn.lock
 CHANGELOG.md
 docker-compose.yml
+CODEOWNERS

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,1 @@
-* @jotanarciso
-* @MagnunAVFAzion
-* @enicio
-* @jcbsfilho
-* @tiagokrebs
+* @jotanarciso @MagnunAVFAzion @enicio @jcbsfilho @tiagokrebs

--- a/lib/build/bundlers/polyfills/node/fs.js
+++ b/lib/build/bundlers/polyfills/node/fs.js
@@ -549,14 +549,20 @@ function readdirSync(path, options) {
   const matchedElements = filesInfos.paths.filter(
     (dir) => dir.startsWith(path) && path !== dir,
   );
-  const elementsInDir = [
-    ...new Set(
-      matchedElements.map(
-        (element) => element.replace(`${path}/`, '').split('/')[0],
+  let elementsInDir;
+  if (path === '/') {
+    elementsInDir = matchedElements.filter(
+      (element) => !element.substring(1).includes('/'),
+    );
+  } else {
+    elementsInDir = [
+      ...new Set(
+        matchedElements.map(
+          (element) => element.replace(`${path}/`, '').split('/')[0],
+        ),
       ),
-    ),
-  ];
-
+    ];
+  }
   // generate the list of elements in dir (strings or Dirents)
   if (options.withFileTypes) {
     result = elementsInDir.map((element) => {


### PR DESCRIPTION
Fixing the fs polyfill when readdirsync and path == /, in this case the worker goes into a loop and crashes the process.