### PR TITLE
fix: angular deliver preset

### DIFF
--- a/lib/presets/custom/angular/deliver/prebuild.js
+++ b/lib/presets/custom/angular/deliver/prebuild.js
@@ -1,4 +1,6 @@
-import { exec, getPackageManager, Manifest } from '#utils';
+import { exec, getPackageManager, Manifest, feedback } from '#utils';
+import path from 'path';
+import fs from 'fs-extra';
 
 const packageManager = await getPackageManager();
 
@@ -18,11 +20,39 @@ async function prebuild() {
 
   Manifest.setRoute({
     from: '/',
-    to: '.edge/storage',
+    to: path.join('.edge', 'storage'),
     priority: 1,
     type: 'deliver',
   });
   Manifest.generate();
+
+  // Move the contents of the 'Browser' folder, which contains static files, to the root of the storage.
+  const oldPath = path.join(process.cwd(), '.edge', 'storage', 'browser');
+  const newPath = path.join(process.cwd(), '.edge', 'storage');
+
+  const files = await fs.readdir(oldPath);
+  await Promise.all(
+    files.map(async (file) => {
+      await fs.move(path.join(oldPath, file), path.join(newPath, file));
+    }),
+  );
+
+  // Remove the original folder
+  await fs.remove(oldPath);
+
+  // If the folder exists, it means that the application is using server-side rendering (SSR)
+  // functionalities. In this case, a warning message is logged.
+  const serverFolderPath = path.join(
+    process.cwd(),
+    '.edge',
+    'storage',
+    'server',
+  );
+  if (fs.existsSync(serverFolderPath)) {
+    feedback.prebuild.warn(
+      `It looks like you are using SSR functionalities. Server-side functionality will not work in 'deliver' mode.`,
+    );
+  }
 }
 
 export default prebuild;

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "events": "^3.3.0",
     "fast-glob": "^3.3.1",
     "form-data": "^4.0.0",
+    "fs-extra": "^11.2.0",
     "https-browserify": "^1.0.0",
     "inquirer": "^9.2.7",
     "install": "^0.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4268,7 +4268,7 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.0.0:
+fs-extra@^11.0.0, fs-extra@^11.2.0:
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
   integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==


### PR DESCRIPTION
### Problem

In the new version of Angular (which is initialized by default by the Azion CLI) it has SSR functionalities. As a result, the folder structure resulting from the build has a new subdivision: Browser and Server. We currently only support code on the Browser side (in deliver mode).

### Resolution
This PR moves the contents of the '.edge/storage/browser' folder to the root of the storage (.edge/storage/) and displays an alert if the user is using SSR resources.