### PR TITLE
fix: node process polyfill to commonjs

### DIFF
--- a/lib/build/bundlers/polyfills/node/globals/process.cjs
+++ b/lib/build/bundlers/polyfills/node/globals/process.cjs
@@ -1,7 +1,6 @@
-/* eslint-disable prefer-rest-params */
-/* eslint-disable no-use-before-define */
-/* eslint-disable no-shadow */
-/* eslint-disable func-names */
+/* eslint-disable */
+// shim for using process in browser
+var process = (module.exports = {});
 
 /*
  * Copyright Azion
@@ -12,26 +11,12 @@
  * repo: https://github.com/defunctzombie/node-process
  */
 
-// shim for using process in browser
-// globalThis.process = process;
+var cachedSetTimeout;
+var cachedClearTimeout;
 
-// cached from whatever global is present so that test runners that stub it
-// don't break things.  But we need to wrap it in a try catch in case it is
-// wrapped in strict mode code which doesn't define any globals.  It's inside a
-// function because try/catches deoptimize in certain engines.
-
-let cachedSetTimeout;
-let cachedClearTimeout;
-
-/**
- *
- */
 function defaultSetTimout() {
   throw new Error('setTimeout has not been defined');
 }
-/**
- *
- */
 function defaultClearTimeout() {
   throw new Error('clearTimeout has not been defined');
 }
@@ -55,14 +40,9 @@ function defaultClearTimeout() {
     cachedClearTimeout = defaultClearTimeout;
   }
 })();
-/**
-/**
- * @param {Function} fun - The function to be executed.
- * @returns {void} Returns nothing.
- */
 function runTimeout(fun) {
   if (cachedSetTimeout === setTimeout) {
-    // normal enviroments in sane situations
+    //normal enviroments in sane situations
     return setTimeout(fun, 0);
   }
   // if setTimeout wasn't available but was latter defined
@@ -86,14 +66,9 @@ function runTimeout(fun) {
     }
   }
 }
-/**
-/**
- * @param {any} marker - A marker that was returned from calling setTimeout().
- * @returns {void}
- */
 function runClearTimeout(marker) {
   if (cachedClearTimeout === clearTimeout) {
-    // normal enviroments in sane situations
+    //normal enviroments in sane situations
     return clearTimeout(marker);
   }
   // if clearTimeout wasn't available but was latter defined
@@ -118,22 +93,34 @@ function runClearTimeout(marker) {
     }
   }
 }
-let queue = [];
-let draining = false;
-let currentQueue;
-let queueIndex = -1;
+var queue = [];
+var draining = false;
+var currentQueue;
+var queueIndex = -1;
 
-/**
- *
- */
+function cleanUpNextTick() {
+  if (!draining || !currentQueue) {
+    return;
+  }
+  draining = false;
+  if (currentQueue.length) {
+    queue = currentQueue.concat(queue);
+  } else {
+    queueIndex = -1;
+  }
+  if (queue.length) {
+    drainQueue();
+  }
+}
+
 function drainQueue() {
   if (draining) {
     return;
   }
-  const timeout = runTimeout(cleanUpNextTick);
+  var timeout = runTimeout(cleanUpNextTick);
   draining = true;
 
-  let len = queue.length;
+  var len = queue.length;
   while (len) {
     currentQueue = queue;
     queue = [];
@@ -150,32 +137,10 @@ function drainQueue() {
   runClearTimeout(timeout);
 }
 
-/**
- *
- */
-function cleanUpNextTick() {
-  if (!draining || !currentQueue) {
-    return;
-  }
-  draining = false;
-  if (currentQueue.length) {
-    queue = currentQueue.concat(queue);
-  } else {
-    queueIndex = -1;
-  }
-  if (queue.length) {
-    drainQueue();
-  }
-}
-
-/**
- *
- */
-
-const nextTick = function (fun) {
-  const args = new Array(arguments.length - 1);
+process.nextTick = function (fun) {
+  var args = new Array(arguments.length - 1);
   if (arguments.length > 1) {
-    for (let i = 1; i < arguments.length; i++) {
+    for (var i = 1; i < arguments.length; i++) {
       args[i - 1] = arguments[i];
     }
   }
@@ -186,10 +151,6 @@ const nextTick = function (fun) {
 };
 
 // v8 likes predictible objects
-/**
- * @param {Function} fun - return a item
- * @param {Array} array - return a array
- */
 function Item(fun, array) {
   this.fun = fun;
   this.array = array;
@@ -197,68 +158,43 @@ function Item(fun, array) {
 Item.prototype.run = function () {
   this.fun.apply(null, this.array);
 };
-const title = 'browser';
-const browser = true;
-const env = {};
-const argv = [];
-const version = ''; // empty string to avoid regexp issues
-const versions = { node: '18.3.1' }; // fake version
+process.title = 'browser';
+process.browser = true;
+process.env = {};
+process.argv = [];
+process.version = ''; // empty string to avoid regexp issues
+process.versions = { node: '18.3.1' };
 
-/**
- *
- */
 function noop() {}
 
-const on = noop;
-const addListener = noop;
-const once = noop;
-const off = noop;
-const removeListener = noop;
-const removeAllListeners = noop;
-const emit = noop;
-const prependListener = noop;
-const prependOnceListener = noop;
+process.on = noop;
+process.addListener = noop;
+process.once = noop;
+process.off = noop;
+process.removeListener = noop;
+process.removeAllListeners = noop;
+process.emit = noop;
+process.prependListener = noop;
+process.prependOnceListener = noop;
 
-const listeners = function () {
+process.listeners = function (name) {
   return [];
 };
 
-const binding = function () {
-  throw new Error('const binding is not supported');
+process.binding = function (name) {
+  throw new Error('process.binding is not supported');
 };
 
-const cwd = function () {
+process.cwd = function () {
   return '/';
 };
-const chdir = function () {
+
+process.chdir = function (dir) {
   throw new Error('process.chdir is not supported');
 };
-const umask = function () {
+process.umask = function () {
   return 0;
 };
 
-const process = {
-  nextTick,
-  title,
-  browser,
-  env,
-  argv,
-  version,
-  versions,
-  on,
-  addListener,
-  once,
-  off,
-  removeListener,
-  removeAllListeners,
-  emit,
-  prependListener,
-  prependOnceListener,
-  listeners,
-  binding,
-  cwd,
-  chdir,
-  umask,
-};
-
 globalThis.process = process;
+globalThis.process.env ??= {};

--- a/lib/build/bundlers/polyfills/polyfills-manager.js
+++ b/lib/build/bundlers/polyfills/polyfills-manager.js
@@ -8,7 +8,8 @@ const nextNodePresetPath = `${libDirPath}/presets/custom/next/compute/node`;
 const nodePolyfillsPath = `${polyfillsPath}/node`;
 
 /**
- * External polyfills are resolved in the build, but as they are for the local environment (Vulcan dev) they are located in #env/polyfills.
+ * External polyfills are resolved in the build, but as they are for the local
+ * environment (Vulcan dev) they are located in #env/polyfills.
  */
 const externalPolyfillsPath = `${libDirPath}/env/polyfills`;
 
@@ -71,6 +72,7 @@ class PolyfillsManager {
    * @returns {{ libs: Map<string, string|boolean>, globals: Map<string, string>, alias: Map<string, string>, external: Map<string, string> }} - Object containing libs and globals.
    */
   buildPolyfills() {
+    // global polyfills
     this.setGlobal('buffer', `${nodePolyfillsPath}/globals/buffer.js`);
     this.setGlobal('console', require.resolve('console-browserify'));
     this.setGlobal('navigator', `${nodePolyfillsPath}/globals/navigator.js`);
@@ -78,13 +80,13 @@ class PolyfillsManager {
       'performance',
       `${nodePolyfillsPath}/globals/performance.js`,
     );
-    this.setGlobal('process', `${nodePolyfillsPath}/globals/process.js`);
+    this.setGlobal('process', `${nodePolyfillsPath}/globals/process.cjs`);
     this.setGlobal('__dirname', `${nodePolyfillsPath}/globals/path-dirname.js`);
     this.setGlobal(
       '__filename',
       `${nodePolyfillsPath}/globals/path-dirname.js`,
     );
-
+    // libs polyfills (fallbacks)
     this.setLib('accepts', require.resolve('accepts'));
     this.setLib('buffer', require.resolve('buffer/'));
     this.setLib('child_process', `${nodePolyfillsPath}/_empty.js`);
@@ -104,7 +106,7 @@ class PolyfillsManager {
     this.setLib('os', require.resolve('os-browserify/browser'));
     this.setLib('path', require.resolve('path-browserify'));
     this.setLib('perf_hooks', `${nodePolyfillsPath}/_empty.js`);
-    this.setLib('process', `${nodePolyfillsPath}/globals/process.js`);
+    this.setLib('process', `${nodePolyfillsPath}/globals/process.cjs`);
     this.setLib('querystring', require.resolve('querystring-es3/'));
     this.setLib('readline', `${nodePolyfillsPath}/_empty.js`);
     this.setLib('repl', `${nodePolyfillsPath}/_empty.js`);
@@ -143,9 +145,11 @@ class PolyfillsManager {
       require.resolve('@fastly/http-compute-js'),
     );
 
+    // alias polyfills
     this.setAlias('util', require.resolve('util/'));
-    this.setAlias('process', `${nodePolyfillsPath}/globals/process.js`);
+    this.setAlias('process', `${nodePolyfillsPath}/globals/process.cjs`);
 
+    // external polyfills
     this.setExternal(
       'async_hooks',
       `${externalPolyfillsPath}/async-hooks/async-hooks.polyfills.js`,


### PR DESCRIPTION
It was identified that the node:process(esm) polyfill when used with webpack does not allow the process.env to be changed.

Webpack replaces all occurrences of process.env with an object that contains the environment variables defined at compile time. If your code is trying to modify process.env after Webpack has already made its replacements, this can cause problems.

Therefore, when you export as CommonJS, you can override process.env because modules are processed at request time. However, when you export as ESM, you cannot override process.env because the modules are processed before any code is executed.

```js
This is what is causing the error TypeError: Cannot set property env of #<Object> which has only one getter.
```