### PR TITLE
fix: order code injection build

### DIFF
--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -336,7 +336,18 @@ class Dispatcher {
     const workerGlobalVars = prebuildResult?.workerGlobalVars || null;
     const builderPlugins = prebuildResult?.builderPlugins || null;
 
-    let codeToInjectInHandler = '';
+    /**
+     * Object containing code to be injected in a handler.
+     * @typedef {object} CodeToInjectInHandler
+     * @property {string} onEntry - The code that will be injected into entry.
+     * @property {string} onBanner - The code that will be injected into the worker banner.
+     */
+
+    /**
+     * Code to be injected in a handler.
+     * @type {CodeToInjectInHandler}
+     */
+    const codeToInjectInHandler = { onEntry: '', onBanner: '' };
 
     createDotEnvFile(isWindows);
 
@@ -348,7 +359,7 @@ class Dispatcher {
     if (workerGlobalVars) {
       // return global vars definitions to inject in worker code.
       // ex: { X: 1, Y: 2} returns `globalThis.X=1; globalThis.Y=2;`
-      codeToInjectInHandler += Object.keys(workerGlobalVars).reduce(
+      codeToInjectInHandler.onBanner += Object.keys(workerGlobalVars).reduce(
         (accumulator, currentKey) =>
           `${accumulator} globalThis.${currentKey}=${workerGlobalVars[currentKey]};`,
         ' ',
@@ -368,12 +379,12 @@ class Dispatcher {
           : `''`;
 
       // eslint-disable-next-line
-      codeToInjectInHandler += `globalThis.vulcan = {}; globalThis.vulcan.FS_PATH_PREFIX_TO_REMOVE = ${prefix};\n${content}`;
+      codeToInjectInHandler.onBanner += `globalThis.vulcan = {}; globalThis.vulcan.FS_PATH_PREFIX_TO_REMOVE = ${prefix};\n${content}`;
     }
 
     // handle files to inject in handler
     if (filesToInject) {
-      codeToInjectInHandler += filesToInject.reduce(
+      codeToInjectInHandler.onEntry += filesToInject.reduce(
         (accumulator, filePath) =>
           `${accumulator} ${readFileSync(filePath, 'utf-8')}`,
         ' ',
@@ -459,11 +470,16 @@ class Dispatcher {
 
       // inject code in handler (build is necessary to pull the modules,
       // this is not a simples code append)
-      if (codeToInjectInHandler && codeToInjectInHandler !== '') {
+      if (codeToInjectInHandler && codeToInjectInHandler.onEntry !== '') {
         let entryContent = readFileSync(buildConfig?.entry, 'utf-8');
-        entryContent = `${codeToInjectInHandler} ${entryContent}`;
+        entryContent = `${codeToInjectInHandler.onEntry} ${entryContent}`;
         entryContent = relocateImportsAndRequires(entryContent);
         writeFileSync(buildConfig?.entry, entryContent);
+      }
+
+      // inject code banner
+      if (codeToInjectInHandler && codeToInjectInHandler.onBanner !== '') {
+        buildConfig.contentToInject = codeToInjectInHandler.onBanner;
       }
 
       if (builderPlugins) {


### PR DESCRIPTION
It was identified that when using the fs polyfill, global code injection into the worker was executed in the entry.
Therefore, it is necessary to separate what is injected into the entry and what is injected into the worker banner.

Error: 

```js
MEM_FILES = globalThis.vulcan.__FILES__;
TypeError: Cannot read properties of undefined (reading '__FILES__')
    at vulcan-node-modules-polyfills:fs
```