### PR TITLE
fix: added to globalVar _ENTRIES for banner injection

### DIFF
--- a/lib/presets/custom/next/compute/default/prebuild/index.js
+++ b/lib/presets/custom/next/compute/default/prebuild/index.js
@@ -103,6 +103,7 @@ async function run() {
   );
 
   return {
+    // onEntry
     filesToInject: [
       // libs used in routing
       // `${getAbsoluteLibDirPath()}/presets/custom/next/compute/default/handler/routing/libs.js`,
@@ -111,7 +112,11 @@ async function run() {
       // file to generate Output. It contains functions references to build
       outputReferencesFilePath,
     ],
+    // onBanner
     workerGlobalVars: {
+      // inject on banner the globalThis._ENTRIES
+      // this is necessary in the order of use, which needs to be defined at the top of the worker
+      _ENTRIES: JSON.stringify({}),
       __CONFIG__: JSON.stringify(processedVercelOutput.vercelConfig),
     },
     builderPlugins: [],


### PR DESCRIPTION
When the next.js project is hybrid, an error was identified in the global variable _ENTRIES.

So it is necessary to inject this var at the top of the worker (onBanner).

Erro: 

```js
RUNTIME ERROR   ReferenceError: _ENTRIES is not defined
```