### PR TITLE
feat: support env vars in local environment

### DIFF
--- a/examples/simple-js-env-vars/README.md
+++ b/examples/simple-js-env-vars/README.md
@@ -1,0 +1,61 @@
+# Simple js Env Vars
+
+In this example we have a basic implementation of using the env vars API.
+
+### Usage:
+
+Run the build command:
+
+```bash
+
+vulcan build
+
+```
+
+Add the `MY_VAR` variable to the `.edge/.env` file.
+
+```bash
+
+MY_VAR="Edge Computing"
+
+```
+
+Run the dev command:
+
+```bash
+
+vulcan dev
+
+```
+
+If everything goes as expected, the application runs successfully.
+
+```bash
+
+➜  simple-js-env-vars vulcan dev
+[Vulcan] › ℹ  info      Using main.js as entrypoint...
+[Vulcan] [Build] › ℹ  info      Loading build context ...
+[Vulcan] [Build] › ℹ  info      Build without postbuild actions.
+[Vulcan] [Pre Build] › ℹ  info      Starting prebuild...
+[Vulcan] [Pre Build] › ✔  success   Prebuild succeeded!
+[Vulcan] [Build] › ℹ  info      Starting Vulcan build...
+[Vulcan] [Build] › ✔  success   Vulcan Build succeeded!
+[Vulcan] [Server] › ✔  success   Function running on port 0.0.0.0:3000, url: http://localhost:3000
+
+```
+
+Open in the browser or execute the command:
+
+```bash
+
+curl --location --request GET 'http://localhost:3000'
+
+```
+
+The answer will be:
+
+```text
+
+Hello Env Vars at Edge Computing!
+
+```

--- a/examples/simple-js-env-vars/README.md
+++ b/examples/simple-js-env-vars/README.md
@@ -12,7 +12,7 @@ vulcan build
 
 ```
 
-Add the `MY_VAR` variable to the `.edge/.env` file.
+Add the `MY_VAR` variable to the `.env` file.
 
 ```bash
 

--- a/examples/simple-js-env-vars/main.js
+++ b/examples/simple-js-env-vars/main.js
@@ -1,0 +1,10 @@
+export default async function main(event) {
+  const key = "MY_VAR";
+  const value = Azion.env.get(key);
+  if(!value) {
+    return new Response("Environment variable not found", { status: 500});
+  }
+  const response = `Hello Env Vars at ${value}!`;
+
+  return new Response(response, { status: 200});
+}

--- a/examples/simple-js-env-vars/main.js
+++ b/examples/simple-js-env-vars/main.js
@@ -1,10 +1,15 @@
+/* eslint-disable */
+/**
+ *
+ * @param event
+ */
 export default async function main(event) {
-  const key = "MY_VAR";
+  const key = 'MY_VAR';
   const value = Azion.env.get(key);
-  if(!value) {
-    return new Response("Environment variable not found", { status: 500});
+  if (!value) {
+    return new Response('Environment variable not found', { status: 500 });
   }
   const response = `Hello Env Vars at ${value}!`;
 
-  return new Response(response, { status: 200});
+  return new Response(response, { status: 200 });
 }

--- a/examples/simple-js-env-vars/package.json
+++ b/examples/simple-js-env-vars/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "simple-js-env-vars",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "aziontech",
+  "license": "ISC"
+}

--- a/examples/simple-js-env-vars/vulcan.config.js
+++ b/examples/simple-js-env-vars/vulcan.config.js
@@ -1,0 +1,7 @@
+export default {
+    entry: "main.js",
+    preset: {
+        name: "javascript",
+        mode: "compute"
+    }
+}

--- a/lib/build/bundlers/esbuild/plugins/azion-polyfills/azion-polyfills.plugins.js
+++ b/lib/build/bundlers/esbuild/plugins/azion-polyfills/azion-polyfills.plugins.js
@@ -12,6 +12,7 @@ const ESBuildAzionModulePlugin = (buildProd) => {
   const NAME = 'vulcan-azion-modules-polyfills';
   const NAMESPACE = NAME;
   const filter = /^azion:/;
+  const prefix = 'azion:';
 
   return {
     /**
@@ -32,6 +33,22 @@ const ESBuildAzionModulePlugin = (buildProd) => {
             options.external.push(key);
           }
         });
+      }
+
+      if (!buildProd) {
+        // build inject prefix (azion:) is not present and the polyfill is Azion
+        options.inject = options.inject || [];
+        if (polyfillManager.external) {
+          [...polyfillManager.external].forEach(([key, value]) => {
+            const hasPrefix = /^[^:]+:/.test(key);
+            if (
+              !hasPrefix &&
+              key?.toLowerCase()?.includes(prefix.replace(':', ''))
+            ) {
+              options.inject.push(value);
+            }
+          });
+        }
       }
 
       /**

--- a/lib/build/bundlers/polyfills/polyfills-manager.js
+++ b/lib/build/bundlers/polyfills/polyfills-manager.js
@@ -159,6 +159,12 @@ class PolyfillsManager {
       `${externalPolyfillsPath}/azion/storage/storage.polyfills.js`,
     );
 
+    // globalThis.Azion
+    this.setExternal(
+      'Azion',
+      `${externalPolyfillsPath}/azion/env-vars/env-vars.polyfills.js`,
+    );
+
     return {
       libs: this.libs,
       globals: this.globals,

--- a/lib/build/bundlers/webpack/plugins/azion-polyfills/azion-polyfills.plugins.js
+++ b/lib/build/bundlers/webpack/plugins/azion-polyfills/azion-polyfills.plugins.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign,class-methods-use-this */
+import { generateWebpackBanner } from '#utils';
 import PolyfillsManager from '../../../polyfills/index.js';
 
 class AzionPolyfillPlugin {
@@ -34,6 +35,26 @@ class AzionPolyfillPlugin {
         return hasPrefix;
       }),
     );
+
+    // build inject prefix (azion:) is not present and the polyfill is Azion
+    if (!this.buildProd) {
+      [...polyfillsManager.external].forEach(([key]) => {
+        const hasPrefix = /^[^:]+:/.test(key);
+        if (
+          !hasPrefix &&
+          key?.toLowerCase()?.includes(this.prefix.replace(':', ''))
+        ) {
+          compiler.options.plugins.push(
+            new compiler.webpack.BannerPlugin({
+              banner: generateWebpackBanner([
+                polyfillsManager.external.get(key),
+              ]),
+              raw: true,
+            }),
+          );
+        }
+      });
+    }
 
     if (this.buildProd) {
       compiler.options.externals = compiler.options.externals || {};

--- a/lib/build/dispatcher/helpers/helpers.js
+++ b/lib/build/dispatcher/helpers/helpers.js
@@ -3,6 +3,7 @@ import {
   mkdirSync,
   writeFileSync,
   promises as fsPromises,
+  existsSync,
 } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
@@ -38,8 +39,10 @@ function createDotEnvFile(isWindows) {
     : join(projectRoot, '.edge');
   const envFilePath = join(outputPath, '.env');
 
-  mkdirSync(outputPath, { recursive: true });
-  writeFileSync(envFilePath, '');
+  if (!existsSync(envFilePath)) {
+    mkdirSync(outputPath, { recursive: true });
+    writeFileSync(envFilePath, '');
+  }
 }
 
 /**

--- a/lib/env/polyfills/azion/env-vars/context/env-vars.context.js
+++ b/lib/env/polyfills/azion/env-vars/context/env-vars.context.js
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
+import fs, { existsSync } from 'fs';
 
 /**
  * This class is a VM context (ENV_VARS_CONTEXT) to handle with environment variables
@@ -10,16 +11,48 @@ import { fileURLToPath } from 'url';
 class EnvVarsContext {
   #envVars;
 
+  #envFile = '.env';
+
+  #pathDefaultEdge = '.edge';
+
   constructor() {
     const projectRoot = process.cwd();
     const isWindows = process.platform === 'win32';
     const outputPath = isWindows
-      ? fileURLToPath(new URL(`file:///${join(projectRoot, '.edge')}`))
-      : join(projectRoot, '.edge');
-    const envFilePath = join(outputPath, '.env');
-    dotenv.config({ path: envFilePath, override: true });
+      ? fileURLToPath(new URL(`file:///${join(projectRoot, '.')}`))
+      : join(projectRoot, '.');
+    const envFilePathRoot = join(outputPath, this.#envFile);
+    const envFilePathEdge = join(
+      outputPath,
+      `${this.#pathDefaultEdge}/${this.#envFile}`,
+    );
+
+    // Load .env file
+    dotenv.config({ path: [envFilePathRoot, envFilePathEdge] });
+
+    this.#cloneEnvRootToEdgeEnv(outputPath);
+
     this.#envVars = process.env;
   }
+
+  /**
+   * Clone .env file to .edge/.env
+   * @param {string} outputPath Root path of user project
+   * @returns {void} - No return
+   */
+  #cloneEnvRootToEdgeEnv = async (outputPath) => {
+    const envFilePathRoot = join(outputPath, this.#envFile);
+    if (!existsSync(envFilePathRoot)) return;
+    const envFileBuffer = await fs.promises.readFile(envFilePathRoot);
+    const envFilePath = join(
+      outputPath,
+      `${this.#pathDefaultEdge}/${this.#envFile}`,
+    );
+    await fs.promises.mkdir(join(outputPath, this.#pathDefaultEdge), {
+      recursive: true,
+    });
+    await fs.promises.writeFile(envFilePath, envFileBuffer);
+  };
 
   /**
    * Azion env vars get method
@@ -31,4 +64,4 @@ class EnvVarsContext {
   }
 }
 
-export default EnvVarsContext;
+export default new EnvVarsContext();

--- a/lib/env/polyfills/azion/env-vars/context/env-vars.context.js
+++ b/lib/env/polyfills/azion/env-vars/context/env-vars.context.js
@@ -1,0 +1,34 @@
+import dotenv from 'dotenv';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * This class is a VM context (ENV_VARS_CONTEXT) to handle with environment variables
+ * @class EnvVarsContext
+ * @description Class to handle with environment variables
+ */
+class EnvVarsContext {
+  #envVars;
+
+  constructor() {
+    const projectRoot = process.cwd();
+    const isWindows = process.platform === 'win32';
+    const outputPath = isWindows
+      ? fileURLToPath(new URL(`file:///${join(projectRoot, '.edge')}`))
+      : join(projectRoot, '.edge');
+    const envFilePath = join(outputPath, '.env');
+    dotenv.config({ path: envFilePath, override: true });
+    this.#envVars = process.env;
+  }
+
+  /**
+   * Azion env vars get method
+   * @param {string} key - The environment variable key
+   * @returns {string} - The environment variable value
+   */
+  get(key) {
+    return this.#envVars[key];
+  }
+}
+
+export default EnvVarsContext;

--- a/lib/env/polyfills/azion/env-vars/context/env-vars.context.test.js
+++ b/lib/env/polyfills/azion/env-vars/context/env-vars.context.test.js
@@ -7,13 +7,13 @@ describe('env-vars context', () => {
   });
 
   it('should return the environment variable value', () => {
-    const envVarsContext = new EnvVarsContext();
+    const envVarsContext = EnvVarsContext;
     const value = envVarsContext.get('MY_ENV_VAR');
     expect(value).toBe('my-env-var-value');
   });
 
   it('should return undefined if the environment variable does not exist', () => {
-    const envVarsContext = new EnvVarsContext();
+    const envVarsContext = EnvVarsContext;
     const value = envVarsContext.get('MY_ENV_VAR_NOT_EXIST');
     expect(value).toBeUndefined();
   });

--- a/lib/env/polyfills/azion/env-vars/context/env-vars.context.test.js
+++ b/lib/env/polyfills/azion/env-vars/context/env-vars.context.test.js
@@ -1,0 +1,20 @@
+import { describe, it, beforeAll } from '@jest/globals';
+import EnvVarsContext from './env-vars.context.js';
+
+describe('env-vars context', () => {
+  beforeAll(() => {
+    process.env.MY_ENV_VAR = 'my-env-var-value';
+  });
+
+  it('should return the environment variable value', () => {
+    const envVarsContext = new EnvVarsContext();
+    const value = envVarsContext.get('MY_ENV_VAR');
+    expect(value).toBe('my-env-var-value');
+  });
+
+  it('should return undefined if the environment variable does not exist', () => {
+    const envVarsContext = new EnvVarsContext();
+    const value = envVarsContext.get('MY_ENV_VAR_NOT_EXIST');
+    expect(value).toBeUndefined();
+  });
+});

--- a/lib/env/polyfills/azion/env-vars/context/index.js
+++ b/lib/env/polyfills/azion/env-vars/context/index.js
@@ -1,0 +1,3 @@
+import EnvVarsContext from './env-vars.context.js';
+
+export default { EnvVarsContext };

--- a/lib/env/polyfills/azion/env-vars/env-vars.polyfills.js
+++ b/lib/env/polyfills/azion/env-vars/env-vars.polyfills.js
@@ -1,0 +1,25 @@
+/**
+ * @file env-vars.polyfills.js
+ * @description Polyfills for Azion ENV Vars.
+ *
+ * This polyfill is referenced in #build/bundlers/polyfills/polyfills-manager.js
+ * Important: This file is a polyfill for Azion ENV Vars, it should be used only in Azion's Edge Computing environment.
+ * ENV_VARS_CONTEXT is context to VM environment.
+ * @example
+ *
+ * const value = Azion.env.get('MY_ENV_VAR');
+ */
+globalThis.Azion = globalThis.Azion || {};
+
+globalThis.Azion.env = {};
+
+/**
+ * Azion env vars get method
+ * @param {string} key - The environment variable key
+ * @returns {string} - The environment variable value
+ */
+globalThis.Azion.env.get = (key) => {
+  // eslint-disable-next-line no-undef
+  const value = new ENV_VARS_CONTEXT().get(key);
+  return value;
+};

--- a/lib/env/polyfills/azion/env-vars/env-vars.polyfills.js
+++ b/lib/env/polyfills/azion/env-vars/env-vars.polyfills.js
@@ -20,6 +20,6 @@ globalThis.Azion.env = {};
  */
 globalThis.Azion.env.get = (key) => {
   // eslint-disable-next-line no-undef
-  const value = new ENV_VARS_CONTEXT().get(key);
+  const value = ENV_VARS_CONTEXT.get(key);
   return value;
 };

--- a/lib/env/polyfills/azion/env-vars/env-vars.polyfills.test.js
+++ b/lib/env/polyfills/azion/env-vars/env-vars.polyfills.test.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-undef */
+import { describe, it, jest } from '@jest/globals';
+import EnvVarsContext from './context/env-vars.context.js';
+import './env-vars.polyfills.js';
+
+jest.mock('./context/index.js');
+global.ENV_VARS_CONTEXT = EnvVarsContext;
+
+describe('env-vars polyfills', () => {
+  beforeAll(() => {
+    process.env.MY_ENV_VAR = 'my-env-var-value';
+  });
+
+  it('should return the environment variable value', () => {
+    const value = Azion.env.get('MY_ENV_VAR');
+    expect(value).toBe('my-env-var-value');
+  });
+  it('should return undefined if the environment variable does not exist', () => {
+    const value = Azion.env.get('MY_ENV_VAR_NOT_EXIST');
+    expect(value).toBeUndefined();
+  });
+});

--- a/lib/env/polyfills/azion/env-vars/index.js
+++ b/lib/env/polyfills/azion/env-vars/index.js
@@ -1,0 +1,3 @@
+import EnvVarsContext from './context/env-vars.context.js';
+
+export default EnvVarsContext;

--- a/lib/env/polyfills/index.js
+++ b/lib/env/polyfills/index.js
@@ -2,5 +2,12 @@ import fetchContext from './azion/fetch/index.js';
 import FetchEventContext from './azion/fetch-event/index.js';
 import { AsyncHooksContext } from './async-hooks/index.js';
 import { StorageContext } from './azion/storage/index.js';
+import EnvVarsContext from './azion/env-vars/index.js';
 
-export { fetchContext, FetchEventContext, AsyncHooksContext, StorageContext };
+export {
+  fetchContext,
+  FetchEventContext,
+  AsyncHooksContext,
+  StorageContext,
+  EnvVarsContext,
+};

--- a/lib/env/runtime.env.js
+++ b/lib/env/runtime.env.js
@@ -5,6 +5,7 @@ import {
   FetchEventContext,
   AsyncHooksContext,
   StorageContext,
+  EnvVarsContext,
 } from './polyfills/index.js';
 
 /**
@@ -66,6 +67,9 @@ function runtime(code) {
 
     // Storage Context
     context.STORAGE_CONTEXT = StorageContext;
+
+    // EnvVars Context
+    context.ENV_VARS_CONTEXT = EnvVarsContext;
 
     return context;
   };

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "cookie": "^0.6.0",
     "crypto-browserify": "^3.12.0",
     "deepmerge": "^4.3.1",
+    "dotenv": "^16.4.4",
     "edge-runtime": "^2.4.5",
     "esbuild": "^0.19.7",
     "escape-string-regexp": "^5.0.0",

--- a/tests/e2e/simple-js-env-vars.test.js
+++ b/tests/e2e/simple-js-env-vars.test.js
@@ -1,3 +1,4 @@
+import { expect } from '@jest/globals';
 import supertest from 'supertest';
 import projectInitializer from '../utils/project-initializer.js';
 import projectStop from '../utils/project-stop.js';
@@ -22,7 +23,18 @@ describe('E2E - simple-js-env-vars project', () => {
 
     request = supertest(localhostBaseUrl);
 
-    await execCommandInContainer(`sh -c 'rm -rf .edge'`, `/${EXAMPLE_PATH}`);
+    await execCommandInContainer(
+      `sh -c 'rm -rf .edge && rm -rf .env'`,
+      `/${EXAMPLE_PATH}`,
+    );
+
+    // eslint-disable-next-line jest/no-standalone-expect
+    if (expect.getState().currentTestName.includes('200')) {
+      await execCommandInContainer(
+        `sh -c 'echo "MY_VAR=EdgeComputing" > .env'`,
+        `/${EXAMPLE_PATH}/`,
+      );
+    }
 
     await projectInitializer(
       EXAMPLE_PATH,
@@ -47,13 +59,6 @@ describe('E2E - simple-js-env-vars project', () => {
   });
 
   test('should receive a 200 status code and env var defined in .env file', async () => {
-    // Add MY_VAR to .env file
-    await execCommandInContainer(
-      `sh -c 'echo "MY_VAR=EdgeComputing" > .env'`,
-      `/${EXAMPLE_PATH}/.edge`,
-      true,
-    );
-
     const response = await request
       .get('/')
       .expect(200)

--- a/tests/e2e/simple-js-env-vars.test.js
+++ b/tests/e2e/simple-js-env-vars.test.js
@@ -1,0 +1,64 @@
+import supertest from 'supertest';
+import projectInitializer from '../utils/project-initializer.js';
+import projectStop from '../utils/project-stop.js';
+import {
+  execCommandInContainer,
+  getContainerPort,
+} from '../utils/docker-env-actions.js';
+
+// timeout in minutes
+const TIMEOUT = 1 * 60 * 1000;
+
+let serverPort;
+let localhostBaseUrl;
+const EXAMPLE_PATH = '/examples/simple-js-env-vars';
+
+describe('E2E - simple-js-env-vars project', () => {
+  let request;
+
+  beforeEach(async () => {
+    serverPort = getContainerPort();
+    localhostBaseUrl = `http://0.0.0.0:${serverPort}`;
+
+    request = supertest(localhostBaseUrl);
+
+    await execCommandInContainer(`sh -c 'rm -rf .edge'`, `/${EXAMPLE_PATH}`);
+
+    await projectInitializer(
+      EXAMPLE_PATH,
+      'javascript',
+      'compute',
+      serverPort,
+      false,
+    );
+  }, TIMEOUT);
+
+  afterEach(async () => {
+    await projectStop(serverPort, EXAMPLE_PATH.replace('/examples/', ''));
+  }, TIMEOUT);
+
+  test('should receive a 500 status code and env var not defined in .env file', async () => {
+    const response = await request
+      .get('/')
+      .expect(500)
+      .expect('Content-Type', /text\/plain/);
+
+    expect(response.text).toContain('Environment variable not found');
+  });
+
+  test('should receive a 200 status code and env var defined in .env file', async () => {
+    // Add MY_VAR to .env file
+    await execCommandInContainer(
+      `sh -c 'echo "MY_VAR=EdgeComputing" > .env'`,
+      `/${EXAMPLE_PATH}/.edge`,
+      true,
+    );
+
+    const response = await request
+      .get('/')
+      .expect(200)
+      .expect('Content-Type', /text\/plain/);
+
+    expect(response.text).toContain('Hello Env Vars');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3467,6 +3467,11 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^16.4.4:
+  version "16.4.4"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.4.tgz#a26e7bb95ebd36272ebb56edb80b826aecf224c1"
+  integrity sha512-XvPXc8XAQThSjAbY6cQ/9PcBXmFoWuw1sQ3b8HqUCR6ziGXjkTi//kB9SWa2UwqlgdAIuRqAa/9hVljzPehbYg==
+
 duplexer2@~0.1.0:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"


### PR DESCRIPTION
Adding support [Azion environment-variables](https://www.azion.com/en/documentation/products/edge-functions/environment-variables/)  in local environment.

```js
  const apiToken = Azion.env.get('API_SERVICE_TOKEN');
```

- We are adding support for the env-vars api for the local environment.
   - This `polyfill` loads the .env  variables.
- Inserted the usage example in `/examples/simple-js-env-vars`.

Use:

To test usage, check `/examples/simple-js-env-vars/README.md`
