### PR TITLE
feat(experimental): firewall event api support

### DIFF
--- a/examples/simple-js-firewall-event/README.md
+++ b/examples/simple-js-firewall-event/README.md
@@ -1,0 +1,65 @@
+# Simple js Firewall Event
+
+This is an example of a firewall event, it shows how to add headers and how to respond with status code and metadata.
+
+### Usage:
+
+Run the build command:
+
+```bash
+
+vulcan build --firewall
+
+```
+
+
+Run the dev command:
+
+```bash
+
+vulcan dev --firewall
+
+```
+
+If everything goes as expected, the application runs successfully.
+
+```bash
+
+simple-js-firewall-event vulcan dev --firewall
+[Vulcan] › ℹ  info      Using main.js as entrypoint...
+[Vulcan] [Build] › ℹ  info      Loading build context ...
+[Vulcan] [Build] › ℹ  info      Build without postbuild actions.
+[Vulcan] [Pre Build] › ℹ  info      Starting prebuild...
+[Vulcan] [Pre Build] › ✔  success   Prebuild succeeded!
+[Vulcan] [Build] › ℹ  info      Starting Vulcan build...
+[Vulcan] [Build] › ✔  success   Vulcan Build succeeded!
+[Vulcan] [Server] › ✔  success   Function running on port 0.0.0.0:3000, url: http://localhost:3000
+
+```
+
+Open a new terminal and run the command below:
+
+```bash
+
+curl -I --location --request GET 'http://localhost:3000'
+
+```
+
+The output will be:
+
+```bash
+
+➜  curl -I --location --request GET 'http://localhost:3000'
+HTTP/1.1 417 Expectation Failed
+content-type: application/json; charset=utf-8
+x-azion-outcome: respondWith
+x-broccoli-cooking-method: Barbecue
+x-country-name: United States
+x-fire-status: On
+x-fire-type: Coal
+Date: Mon, 26 Feb 2024 14:24:01 GMT
+Connection: keep-alive
+Keep-Alive: timeout=5
+Transfer-Encoding: chunked
+
+```

--- a/examples/simple-js-firewall-event/main.js
+++ b/examples/simple-js-firewall-event/main.js
@@ -1,0 +1,24 @@
+/* eslint-disable */
+
+addEventListener("firewall", (event) => {
+  // https://www.azion.com/en/documentation/products/edge-application/edge-functions/runtime/api-reference/metadata/
+  // In local development, the metadata is mocked.
+  const { geoip_country_name } = event.request.metadata;
+
+  event.addRequestHeader("X-Broccoli-Cooking-Method", "Boiling");
+  event.addResponseHeader("X-Broccoli-Cooking-Method", "Barbecue");
+
+  // event respondWith or event.deny must be called
+  event.respondWith(
+    new Response("The broccoli is burning.", {
+      headers: {
+        "X-Fire-Status": "On",
+        "X-Fire-Type": "Coal",
+        "X-Country-Name": geoip_country_name,
+      },
+      status: 417,
+    })
+  );
+
+  // event.deny();
+});

--- a/examples/simple-js-firewall-event/package.json
+++ b/examples/simple-js-firewall-event/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "simple-js-firewall-event",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "aziontech",
+  "license": "MIT"
+}

--- a/examples/simple-js-firewall-event/vulcan.config.js
+++ b/examples/simple-js-firewall-event/vulcan.config.js
@@ -1,0 +1,8 @@
+export default {
+    entry: "main.js",
+    preset: {
+        name: "javascript",
+        mode: "compute"
+    },
+    useOwnWorker: true,
+}

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -44,7 +44,7 @@ const isWindows = process.platform === 'win32';
  * dispatcher.run();
  */
 class Dispatcher {
-  #firewall;
+  #isFirewall;
 
   /**
    * Create a build configuration object.
@@ -59,12 +59,12 @@ class Dispatcher {
    * @param {string[]|undefined} [config.memoryFS] - Reference to dirs that contains files to be injected in worker memory.
    * @param {object} [config.custom] - Custom Bundle configuration.
    * @param {string} vulcanLibPath - Vulcan lib absolute path
-   * @param {boolean} firewall - Enable firewall for local environment.
+   * @param {boolean} isFirewall - (Experimental) Enable isFirewall for local environment.
    */
   constructor(
     config,
     vulcanLibPath = getAbsoluteLibDirPath(),
-    firewall = false,
+    isFirewall = false,
   ) {
     /* configuration */
     this.entry = config.entry;
@@ -78,7 +78,7 @@ class Dispatcher {
     this.custom = config.custom;
     /* generate */
     this.vulcanLibPath = vulcanLibPath;
-    this.#firewall = firewall;
+    this.#isFirewall = isFirewall;
   }
 
   /**
@@ -213,7 +213,7 @@ class Dispatcher {
         'worker.js',
       );
       // use firewall worker
-      if (this.#firewall) {
+      if (this.#isFirewall) {
         workerFilePath = join(
           this.vulcanLibPath,
           'providers',
@@ -266,7 +266,7 @@ class Dispatcher {
             newHandlerContent,
             false,
           );
-        if (!this.#firewall && isFirewallEvent) {
+        if (!this.#isFirewall && isFirewallEvent) {
           throw new Error(Messages.build.error.firewall_disabled);
         }
       } catch (error) {

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -12,6 +12,7 @@ import {
   getProjectJsonFile,
   relocateImportsAndRequires,
   injectFilesInMem,
+  helperHandlerCode,
 } from '#utils';
 import { Messages } from '#constants';
 import vulcan from '../../env/vulcan.env.js';
@@ -43,6 +44,8 @@ const isWindows = process.platform === 'win32';
  * dispatcher.run();
  */
 class Dispatcher {
+  #firewall;
+
   /**
    * Create a build configuration object.
    * @param {object} config - The configuration object.
@@ -56,8 +59,13 @@ class Dispatcher {
    * @param {string[]|undefined} [config.memoryFS] - Reference to dirs that contains files to be injected in worker memory.
    * @param {object} [config.custom] - Custom Bundle configuration.
    * @param {string} vulcanLibPath - Vulcan lib absolute path
+   * @param {boolean} firewall - Enable firewall for local environment.
    */
-  constructor(config, vulcanLibPath = getAbsoluteLibDirPath()) {
+  constructor(
+    config,
+    vulcanLibPath = getAbsoluteLibDirPath(),
+    firewall = false,
+  ) {
     /* configuration */
     this.entry = config.entry;
     this.builder = config.builder;
@@ -70,6 +78,7 @@ class Dispatcher {
     this.custom = config.custom;
     /* generate */
     this.vulcanLibPath = vulcanLibPath;
+    this.#firewall = firewall;
   }
 
   /**
@@ -196,12 +205,22 @@ class Dispatcher {
 
     // use providers
     if (!this.useOwnWorker) {
-      const workerFilePath = join(
+      // use default worker
+      let workerFilePath = join(
         this.vulcanLibPath,
         'providers',
         'azion',
         'worker.js',
       );
+      // use firewall worker
+      if (this.#firewall) {
+        workerFilePath = join(
+          this.vulcanLibPath,
+          'providers',
+          'azion',
+          'firewall_worker.js',
+        );
+      }
 
       const workerTemplate = readFileSync(workerFilePath, 'utf-8');
       newHandlerContent = workerTemplate.replace(
@@ -237,6 +256,18 @@ class Dispatcher {
             '__JS_CODE__',
             entrypointModified,
           );
+        }
+
+        // this is necessary when useOwnWorker is true and --firewall is not set
+        const { matchEvent: isFirewallEvent } =
+          helperHandlerCode.checkAndChangeAddEventListener(
+            'firewall',
+            'firewall',
+            newHandlerContent,
+            false,
+          );
+        if (!this.#firewall && isFirewallEvent) {
+          throw new Error(Messages.build.error.firewall_disabled);
         }
       } catch (error) {
         feedback.build.error(error.message);

--- a/lib/commands/build.commands.js
+++ b/lib/commands/build.commands.js
@@ -65,6 +65,7 @@ function getPresetValue(
  * @param {string} [options.mode] - Mode in which to run the build (e.g., 'deliver', 'compute').
  * @param {boolean} [options.useNodePolyfills] - Whether to use Node.js polyfills.
  * @param {boolean} [options.useOwnWorker] - This flag indicates that the constructed code inserts its own worker expression, such as addEventListener("fetch") or similar, without the need to inject a provider.
+ * @param {boolean} [firewall] - Enable firewall for local environment.
  * @returns {Promise<void>} - A promise that resolves when the build is complete.
  * @example
  *
@@ -75,14 +76,10 @@ function getPresetValue(
  *   useNodePolyfills: false
  * });
  */
-async function buildCommand({
-  entry,
-  builder,
-  preset,
-  mode,
-  useNodePolyfills,
-  useOwnWorker,
-}) {
+async function buildCommand(
+  { entry, builder, preset, mode, useNodePolyfills, useOwnWorker },
+  firewall,
+) {
   const customConfigurationModule = await vulcan.loadVulcanConfigFile();
   const vulcanVariables = await vulcan.readVulcanEnv('local');
 
@@ -143,7 +140,7 @@ async function buildCommand({
   }
 
   const BuildDispatcher = (await import('#build')).default;
-  const buildDispatcher = new BuildDispatcher(config);
+  const buildDispatcher = new BuildDispatcher(config, undefined, firewall);
 
   await buildDispatcher.run();
 }

--- a/lib/commands/build.commands.js
+++ b/lib/commands/build.commands.js
@@ -65,7 +65,7 @@ function getPresetValue(
  * @param {string} [options.mode] - Mode in which to run the build (e.g., 'deliver', 'compute').
  * @param {boolean} [options.useNodePolyfills] - Whether to use Node.js polyfills.
  * @param {boolean} [options.useOwnWorker] - This flag indicates that the constructed code inserts its own worker expression, such as addEventListener("fetch") or similar, without the need to inject a provider.
- * @param {boolean} [firewall] - Enable firewall for local environment.
+ * @param {boolean} [isFirewall] - (Experimental) Enable isFirewall for local environment.
  * @returns {Promise<void>} - A promise that resolves when the build is complete.
  * @example
  *
@@ -78,7 +78,7 @@ function getPresetValue(
  */
 async function buildCommand(
   { entry, builder, preset, mode, useNodePolyfills, useOwnWorker },
-  firewall,
+  isFirewall,
 ) {
   const customConfigurationModule = await vulcan.loadVulcanConfigFile();
   const vulcanVariables = await vulcan.readVulcanEnv('local');
@@ -140,7 +140,7 @@ async function buildCommand(
   }
 
   const BuildDispatcher = (await import('#build')).default;
-  const buildDispatcher = new BuildDispatcher(config, undefined, firewall);
+  const buildDispatcher = new BuildDispatcher(config, undefined, isFirewall);
 
   await buildDispatcher.run();
 }

--- a/lib/commands/dev.commands.js
+++ b/lib/commands/dev.commands.js
@@ -13,16 +13,17 @@ import { Commands } from '#namespaces';
  *  entry point for the development server.
  * @param {object} options - An object containing configuration options.
  * @param {string|number} options.port - The port number on which the development server will run.
+ * @param {boolean} options.firewall - Enable firewall for local environment.
  * @returns {Promise<void>} - A promise that resolves when the development server starts.
  * @example
  *
  * devCommand('./path/to/entry.js', { port: 3000 });
  */
-async function devCommand(entry, { port }) {
+async function devCommand(entry, { port, firewall }) {
   const parsedPort = parseInt(port, 10);
   const { server } = await import('#env');
   const entryPoint = entry || join(process.cwd(), '.edge/worker.js');
-  server(entryPoint, parsedPort);
+  server(entryPoint, parsedPort, firewall);
 }
 
 export default devCommand;

--- a/lib/commands/dev.commands.js
+++ b/lib/commands/dev.commands.js
@@ -13,7 +13,7 @@ import { Commands } from '#namespaces';
  *  entry point for the development server.
  * @param {object} options - An object containing configuration options.
  * @param {string|number} options.port - The port number on which the development server will run.
- * @param {boolean} options.firewall - Enable firewall for local environment.
+ * @param {boolean} options.firewall - (Experimental) Enable firewall for local environment.
  * @returns {Promise<void>} - A promise that resolves when the development server starts.
  * @example
  *

--- a/lib/constants/messages/build.messages.js
+++ b/lib/constants/messages/build.messages.js
@@ -25,7 +25,7 @@ const build = {
     prebuild_error_validation_support: (framework, version, runtimes) =>
       `${framework} version (${version}) not supported to "${runtimes}" runtime(s).`,
     firewall_disabled:
-      'Firewall is disabled. Insert in the command line --firewall to enable it.',
+      'Firewall is disabled. Insert in the command line --firewall (Experimental) to enable it.',
   },
   warning: {
     use_node_polyfill_mode_deliver:

--- a/lib/constants/messages/build.messages.js
+++ b/lib/constants/messages/build.messages.js
@@ -24,6 +24,8 @@ const build = {
       `Please run command to install dependencies. e.g ${pckManager} install.`,
     prebuild_error_validation_support: (framework, version, runtimes) =>
       `${framework} version (${version}) not supported to "${runtimes}" runtime(s).`,
+    firewall_disabled:
+      'Firewall is disabled. Insert in the command line --firewall to enable it.',
   },
   warning: {
     use_node_polyfill_mode_deliver:

--- a/lib/env/polyfills/azion/firewall-event/context/firewall-event.context.js
+++ b/lib/env/polyfills/azion/firewall-event/context/firewall-event.context.js
@@ -127,13 +127,16 @@ class FirewallEventContext extends primitives.FetchEvent {
 
   drop() {
     this.#outcome = 'drop';
-    this.#currentResponse = new Response(null);
+    this.#currentResponse = new Response(null, {
+      status: 421,
+      statusText: 'ERR_HTTP2_PROTOCOL_ERROR',
+    });
     this.#response();
   }
 
   continue() {
     this.#outcome = 'continue';
-    this.#currentResponse = new Response(null);
+    this.#currentResponse = new Response('(mocked) continue to origin');
     this.#response();
   }
 

--- a/lib/env/polyfills/azion/firewall-event/context/firewall-event.context.js
+++ b/lib/env/polyfills/azion/firewall-event/context/firewall-event.context.js
@@ -86,7 +86,11 @@ class FirewallEventContext extends primitives.FetchEvent {
     // clone headers to avoid modifying the original response
     const headers = new Headers(response.headers);
     headers.set(OUTCOME_HEADER, this.#outcome);
-    headers.set(CONTENT_TYPE_HEADER, JSON_CONTENT_TYPE);
+    if (headers.has('Content-Type')) {
+      headers.set(CONTENT_TYPE_HEADER, headers.get('Content-Type'));
+    } else {
+      headers.set(CONTENT_TYPE_HEADER, JSON_CONTENT_TYPE);
+    }
     if (this.#responseHeaders && this.#responseHeaders instanceof Headers) {
       Array.from(this.#responseHeaders.entries()).forEach(([header, value]) => {
         headers.set(header, value);

--- a/lib/env/polyfills/azion/firewall-event/context/firewall-event.context.js
+++ b/lib/env/polyfills/azion/firewall-event/context/firewall-event.context.js
@@ -1,0 +1,146 @@
+import primitives from '@edge-runtime/primitives';
+import crypto from 'node:crypto';
+
+const OUTCOME_HEADER = 'X-Azion-Outcome';
+const CONTENT_TYPE_HEADER = 'Content-Type';
+const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
+
+/**
+ * @class FirewallEventContext
+ * @description Class to handle with firewall event context
+ *
+ * This class is a VM context to handle with firewall event context
+ * @example
+ * addEventListener("firewall", (event) => {
+ *  event.deny();
+ * });
+ */
+class FirewallEventContext extends primitives.FetchEvent {
+  #outcome = null;
+
+  #request;
+
+  #currentResponse;
+
+  #responseHeaders;
+
+  constructor(request) {
+    super(request);
+
+    // make request metadata available through the event's Request object.
+    // the value comes directly as a JSON from Nginx.
+    Object.defineProperty(request, 'metadata', {
+      value: Object.freeze(this.#metadata()),
+      writable: false,
+    });
+
+    Object.defineProperty(request, 'id', {
+      value: crypto.randomUUID(),
+      writable: false,
+    });
+
+    Object.defineProperty(request, 'raw_url', {
+      value: () => this.#rawRequest(request),
+      writable: false,
+    });
+
+    this.#request = request;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #rawRequest(request) {
+    let rawRequest = `${request.method} ${request.url} HTTP/1.1\n`;
+    Array.from(request.headers.entries()).forEach(([header, value]) => {
+      rawRequest += `${header}: ${value}\n`;
+    });
+    rawRequest += '\n';
+    return rawRequest;
+  }
+
+  // metadata defined by Nginx, but is mocked here
+  // eslint-disable-next-line class-methods-use-this
+  #metadata() {
+    return {
+      geoip_city_continent_code: 'NA',
+      geoip_city_country_code: 'US',
+      geoip_city_country_name: 'United States',
+      geoip_continent_code: 'NA',
+      geoip_country_code: 'US',
+      geoip_country_name: 'United States',
+      geoip_region: 'NJ',
+      geoip_region_name: 'New Jersey',
+      remote_addr: '127.0.0.1',
+      remote_port: '33440',
+      remote_user: null,
+      server_protocol: 'HTTP/1.1',
+      ssl_cipher: null,
+      ssl_protocol: null,
+      geoip_asn: '14061',
+      geoip_city: 'Clifton',
+    };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #response() {
+    const response = this.#currentResponse;
+    // clone headers to avoid modifying the original response
+    const headers = new Headers(response.headers);
+    headers.set(OUTCOME_HEADER, this.#outcome);
+    headers.set(CONTENT_TYPE_HEADER, JSON_CONTENT_TYPE);
+    if (this.#responseHeaders && this.#responseHeaders instanceof Headers) {
+      Array.from(this.#responseHeaders.entries()).forEach(([header, value]) => {
+        headers.set(header, value);
+      });
+    }
+    return super.respondWith(
+      new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      }),
+    );
+  }
+
+  respondWith(response) {
+    if (!(response instanceof Response) && !(response instanceof Promise)) {
+      throw new TypeError(
+        'respondWith expects a Response or a Promise that resolves to a Response',
+      );
+    }
+    this.#outcome = 'respondWith';
+    this.#currentResponse = response;
+    this.#response();
+  }
+
+  deny() {
+    this.#outcome = 'deny';
+    this.#currentResponse = new Response('', {
+      status: 403,
+      statusText: 'Forbidden',
+    });
+    this.#response();
+  }
+
+  drop() {
+    this.#outcome = 'drop';
+    this.#currentResponse = new Response(null);
+    this.#response();
+  }
+
+  continue() {
+    this.#outcome = 'continue';
+    this.#currentResponse = new Response(null);
+    this.#response();
+  }
+
+  addResponseHeader(header, value) {
+    this.#responseHeaders = new Headers(this.#responseHeaders);
+    this.#responseHeaders.append(header, value);
+  }
+
+  addRequestHeader(header, value) {
+    this.#request.headers[header] = value;
+  }
+}
+
+export default FirewallEventContext;

--- a/lib/env/polyfills/azion/firewall-event/context/firewall-event.context.test.js
+++ b/lib/env/polyfills/azion/firewall-event/context/firewall-event.context.test.js
@@ -1,0 +1,56 @@
+import { expect, test } from '@jest/globals';
+import FirewallEventContext from './firewall-event.context.js';
+
+describe('FirewallEventContext', () => {
+  let event;
+
+  beforeEach(() => {
+    const request = {
+      method: 'GET',
+      url: 'http://localhost',
+      headers: new Headers(),
+    };
+    event = new FirewallEventContext(request);
+  });
+
+  test('should be able to add a response header', () => {
+    event.addResponseHeader('X-Broccoli-Status', 'Broccoli is fine.');
+    event.continue();
+    expect(event.response.headers.get('X-Broccoli-Status')).toBe(
+      'Broccoli is fine.',
+    );
+  });
+
+  test('should be able to continue the request', () => {
+    event.continue();
+    expect(event.response.status).toBe(200);
+  });
+
+  test('should be able to deny the request', () => {
+    event.deny();
+    expect(event.response.status).toBe(403);
+  });
+
+  test('should be able to respond with a custom response', async () => {
+    event.respondWith(
+      new Response('Custom Response', {
+        status: 201,
+      }),
+    );
+    expect(event.response.status).toBe(201);
+    expect(await event.response.text()).toBe('Custom Response');
+  });
+
+  test('should be able to waitUntil a promise to be resolved', async () => {
+    event.waitUntil(
+      new Promise((resolve) => {
+        event.addResponseHeader('X-Broccoli-Status', 'Broccoli is fine.');
+        event.continue();
+        resolve();
+      }),
+    );
+    expect(event.response.headers.get('X-Broccoli-Status')).toBe(
+      'Broccoli is fine.',
+    );
+  });
+});

--- a/lib/env/polyfills/azion/firewall-event/context/index.js
+++ b/lib/env/polyfills/azion/firewall-event/context/index.js
@@ -1,0 +1,3 @@
+import FirewallEventContext from './firewall-event.context.js';
+
+export default FirewallEventContext;

--- a/lib/env/polyfills/azion/firewall-event/index.js
+++ b/lib/env/polyfills/azion/firewall-event/index.js
@@ -1,0 +1,3 @@
+import FirewallEventContext from './context/index.js';
+
+export default FirewallEventContext;

--- a/lib/env/runtime.env.js
+++ b/lib/env/runtime.env.js
@@ -7,11 +7,13 @@ import {
   StorageContext,
   EnvVarsContext,
 } from './polyfills/index.js';
+import FirewallEventContext from './polyfills/azion/firewall-event/index.js';
 
 /**
  * Executes the specified JavaScript code within a sandbox environment,
  * simulating the behavior of edges that use isolates.
  * @param {string} code - The JavaScript code to be executed.
+ * @param {boolean} isFirewallEvent - If the code is a Firewall event.
  * @returns {EdgeRuntime} An instance of the 'EdgeRuntime' class that represents
  *                        the sandboxed environment where the code will be executed.
  *
@@ -40,14 +42,18 @@ import {
  *   console.log(response.status);
  * ```
  */
-function runtime(code) {
+function runtime(code, isFirewallEvent = false) {
   const extend = (context) => {
     context.RESERVED_FETCH = context.fetch.bind(context);
     context.fetch = async (resource, options) =>
       fetchContext(context, resource, options);
 
-    context.FetchEvent = FetchEventContext;
-    context.FirewallEvent = {}; // TODO: Firewall Event
+    // Set the context for the FetchEvent if it's a Firewall event or a Fetch event
+    context.FetchEvent = isFirewallEvent
+      ? FirewallEventContext
+      : FetchEventContext;
+    context.Response = isFirewallEvent ? Response : context.Response;
+
     /*
      * According to the Vercel documentation at https://vercel.com/docs/concepts/functions/edge-functions/edge-runtime#unsupported-apis,
      * the default runtime doesn't support `eval`.

--- a/lib/env/server.env.js
+++ b/lib/env/server.env.js
@@ -52,9 +52,9 @@ async function initializeServer(port, workerCode) {
 
 /**
  * Build to Local Server with polyfill external
- * @param {boolean} firewall - Enable firewall for local environment.
+ * @param {boolean} isFirewall - (Experimental) Enable isFirewall for local environment.
  */
-async function buildToLocalServer(firewall) {
+async function buildToLocalServer(isFirewall) {
   const vulcanEnv = await vulcan.readVulcanEnv('local');
 
   if (!vulcanEnv) {
@@ -63,18 +63,18 @@ async function buildToLocalServer(firewall) {
     throw new Error(msg);
   }
   globalThis.vulcan.buildProd = false;
-  await buildCommand({}, firewall);
+  await buildCommand({}, isFirewall);
 }
 
 /**
  * Handle server operations: start, restart.
  * @param {string} workerPath - Path to the worker file.
  * @param {number} port - The port number.
- * @param {boolean} firewall - Enable firewall for local environment.
+ * @param {boolean} isFirewall - (Experimental) Enable isFirewall for local environment.
  */
-async function manageServer(workerPath, port, firewall) {
+async function manageServer(workerPath, port, isFirewall) {
   try {
-    await buildToLocalServer(firewall);
+    await buildToLocalServer(isFirewall);
 
     const workerCode = await readWorkerCode(workerPath);
 
@@ -91,7 +91,7 @@ async function manageServer(workerPath, port, firewall) {
       );
     } catch (error) {
       if (error.code === 'EADDRINUSE') {
-        await manageServer(workerPath, port + 1, firewall);
+        await manageServer(workerPath, port + 1, isFirewall);
       } else {
         throw error;
       }
@@ -109,9 +109,9 @@ async function manageServer(workerPath, port, firewall) {
  * @param {string} path - Path of the changed file.
  * @param {string} workerPath - Path to the worker file.
  * @param {number} port - The port number.
- * @param {boolean} firewall - Enable firewall for local environment.
+ * @param {boolean} isFirewall - (Experimental) Enable isFirewall for local environment.
  */
-async function handleFileChange(path, workerPath, port, firewall) {
+async function handleFileChange(path, workerPath, port, isFirewall) {
   if (isChangeHandlerRunning) return;
 
   if (
@@ -128,7 +128,7 @@ async function handleFileChange(path, workerPath, port, firewall) {
 
   try {
     feedback.build.info(Messages.build.info.rebuilding);
-    await manageServer(workerPath, port, firewall);
+    await manageServer(workerPath, port, isFirewall);
   } catch (error) {
     debug.error(`Build or server restart failed: ${error}`);
   } finally {
@@ -140,10 +140,10 @@ async function handleFileChange(path, workerPath, port, firewall) {
  * Entry point function to start the server and watch for file changes.
  * @param {string} workerPath - Path to the worker file.
  * @param {number} port - The port number.
- * @param {boolean} firewall - Enable firewall for local environment.
+ * @param {boolean} isFirewall - (Experimental) Enable isFirewall for local environment.
  */
-async function startServer(workerPath, port, firewall) {
-  await manageServer(workerPath, port, firewall); // Initialize the server for the first time
+async function startServer(workerPath, port, isFirewall) {
+  await manageServer(workerPath, port, isFirewall); // Initialize the server for the first time
 
   const watcher = chokidar.watch('./', {
     persistent: true,
@@ -152,7 +152,7 @@ async function startServer(workerPath, port, firewall) {
   });
 
   watcher.on('change', async (path) => {
-    await handleFileChange(path, workerPath, port, firewall);
+    await handleFileChange(path, workerPath, port, isFirewall);
   });
 
   watcher.on('error', (error) => debug.error(`Watcher error: ${error}`));

--- a/lib/env/server.env.js
+++ b/lib/env/server.env.js
@@ -1,4 +1,4 @@
-import { debug, readWorkerFile, feedback } from '#utils';
+import { debug, readWorkerFile, feedback, helperHandlerCode } from '#utils';
 import { Messages } from '#constants';
 import { runServer, EdgeRuntime } from 'edge-runtime';
 import chokidar from 'chokidar';
@@ -34,14 +34,27 @@ async function readWorkerCode(workerPath) {
  * @returns {Promise<EdgeRuntime>} - The initialized server.
  */
 async function initializeServer(port, workerCode) {
-  const execution = runtime(workerCode);
+  // Check if the code is a Firewall event and change it to a Fetch event
+  // This is required at this point because the VM used for the local runtime
+  // server does not support any other type of event than "fetch".
+  const { matchEvent: isFirewallEvent, codeChanged } =
+    helperHandlerCode.checkAndChangeAddEventListener(
+      'firewall',
+      'fetch',
+      workerCode,
+    );
+  // Use the changed code if it's a Firewall event
+  const initialCode = isFirewallEvent ? codeChanged : workerCode;
+
+  const execution = runtime(initialCode, isFirewallEvent);
   return runServer({ port, host: '0.0.0.0', runtime: execution });
 }
 
 /**
  * Build to Local Server with polyfill external
+ * @param {boolean} firewall - Enable firewall for local environment.
  */
-async function buildToLocalServer() {
+async function buildToLocalServer(firewall) {
   const vulcanEnv = await vulcan.readVulcanEnv('local');
 
   if (!vulcanEnv) {
@@ -50,17 +63,18 @@ async function buildToLocalServer() {
     throw new Error(msg);
   }
   globalThis.vulcan.buildProd = false;
-  await buildCommand({});
+  await buildCommand({}, firewall);
 }
 
 /**
  * Handle server operations: start, restart.
  * @param {string} workerPath - Path to the worker file.
  * @param {number} port - The port number.
+ * @param {boolean} firewall - Enable firewall for local environment.
  */
-async function manageServer(workerPath, port) {
+async function manageServer(workerPath, port, firewall) {
   try {
-    await buildToLocalServer();
+    await buildToLocalServer(firewall);
 
     const workerCode = await readWorkerCode(workerPath);
 
@@ -77,7 +91,7 @@ async function manageServer(workerPath, port) {
       );
     } catch (error) {
       if (error.code === 'EADDRINUSE') {
-        await manageServer(workerPath, port + 1);
+        await manageServer(workerPath, port + 1, firewall);
       } else {
         throw error;
       }
@@ -95,8 +109,9 @@ async function manageServer(workerPath, port) {
  * @param {string} path - Path of the changed file.
  * @param {string} workerPath - Path to the worker file.
  * @param {number} port - The port number.
+ * @param {boolean} firewall - Enable firewall for local environment.
  */
-async function handleFileChange(path, workerPath, port) {
+async function handleFileChange(path, workerPath, port, firewall) {
   if (isChangeHandlerRunning) return;
 
   if (
@@ -113,7 +128,7 @@ async function handleFileChange(path, workerPath, port) {
 
   try {
     feedback.build.info(Messages.build.info.rebuilding);
-    await manageServer(workerPath, port);
+    await manageServer(workerPath, port, firewall);
   } catch (error) {
     debug.error(`Build or server restart failed: ${error}`);
   } finally {
@@ -125,9 +140,10 @@ async function handleFileChange(path, workerPath, port) {
  * Entry point function to start the server and watch for file changes.
  * @param {string} workerPath - Path to the worker file.
  * @param {number} port - The port number.
+ * @param {boolean} firewall - Enable firewall for local environment.
  */
-async function startServer(workerPath, port) {
-  await manageServer(workerPath, port); // Initialize the server for the first time
+async function startServer(workerPath, port, firewall) {
+  await manageServer(workerPath, port, firewall); // Initialize the server for the first time
 
   const watcher = chokidar.watch('./', {
     persistent: true,
@@ -136,7 +152,7 @@ async function startServer(workerPath, port) {
   });
 
   watcher.on('change', async (path) => {
-    await handleFileChange(path, workerPath, port);
+    await handleFileChange(path, workerPath, port, firewall);
   });
 
   watcher.on('error', (error) => debug.error(`Watcher error: ${error}`));

--- a/lib/main.js
+++ b/lib/main.js
@@ -88,10 +88,15 @@ function startVulcanProgram() {
       '--useOwnWorker',
       'This flag indicates that the constructed code inserts its own worker expression, such as addEventListener("fetch") or similar, without the need to inject a provider.',
     )
+    .option(
+      '--firewall',
+      'To enable the firewall for local environment (default: false)',
+      false,
+    )
     .action(async (options) => {
       const { buildCommand } = await import('#commands');
       globalThis.vulcan.buildProd = true;
-      await buildCommand(options);
+      await buildCommand(options, options?.firewall);
     });
 
   program
@@ -99,6 +104,11 @@ function startVulcanProgram() {
     .description('Start local environment')
     .arguments('[entry]')
     .option('-p, --port <port>', 'Specify the port', '3000')
+    .option(
+      '--firewall',
+      'To enable the firewall for local environment (default: false)',
+      false,
+    )
     .action(async (entry, options) => {
       const { devCommand } = await import('#commands');
       await devCommand(entry, options);

--- a/lib/main.js
+++ b/lib/main.js
@@ -90,7 +90,7 @@ function startVulcanProgram() {
     )
     .option(
       '--firewall',
-      'To enable the firewall for local environment (default: false)',
+      'To enable the firewall (Experimental) for local environment (default: false)',
       false,
     )
     .action(async (options) => {
@@ -106,7 +106,7 @@ function startVulcanProgram() {
     .option('-p, --port <port>', 'Specify the port', '3000')
     .option(
       '--firewall',
-      'To enable the firewall for local environment (default: false)',
+      'To enable the firewall (Experimental) for local environment (default: false)',
       false,
     )
     .action(async (entry, options) => {

--- a/lib/providers/azion/firewall_worker.js
+++ b/lib/providers/azion/firewall_worker.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+addEventListener('firewall', (event) => {
+  __HANDLER__;
+});

--- a/lib/utils/helperHandlerCode/helperHandlerCode.js
+++ b/lib/utils/helperHandlerCode/helperHandlerCode.js
@@ -1,0 +1,31 @@
+/**
+ * Check and change AddEventListener event
+ * @param {string} eventTarget target event
+ * @param {string} newEvent new event
+ * @param {string} code code to be changed
+ * @param {boolean} replaceCode code to replace
+ * @returns {object} - Object with matchEvent and codeChanged
+ */
+const checkAndChangeAddEventListener = (
+  eventTarget,
+  newEvent,
+  code,
+  replaceCode = true,
+) => {
+  let codeChanged = code;
+  const eventRegex = new RegExp(
+    `addEventListener\\((['"]?)${eventTarget}\\1,`,
+    'g',
+  );
+  const matchEvent = !!code.match(eventRegex);
+  if (matchEvent && replaceCode) {
+    codeChanged = code.replace(eventRegex, `addEventListener("${newEvent}",`);
+  }
+  return { matchEvent, codeChanged };
+};
+
+const helperCheckCode = {
+  checkAndChangeAddEventListener,
+};
+
+export default helperCheckCode;

--- a/lib/utils/helperHandlerCode/helperHandlerCode.test.js
+++ b/lib/utils/helperHandlerCode/helperHandlerCode.test.js
@@ -1,0 +1,29 @@
+import helperHandlerCode from './index.js';
+
+describe('Helper Handler Code Utils', () => {
+  describe('checkAndChangeAddEventListener', () => {
+    it('should return unchanged code and matchEvent as false when there is no firewall event', () => {
+      const code = 'addEventListener("fetch", (event) => {});';
+      const result = helperHandlerCode.checkAndChangeAddEventListener(
+        'firewall',
+        'fetch',
+        code,
+      );
+      expect(result).toEqual({ matchEvent: false, codeChanged: code });
+    });
+
+    it('should return changed code and matchEvent as true when there is a firewall event', () => {
+      const code = 'addEventListener("firewall", (event) => {});';
+      const expectedCode = 'addEventListener("fetch", (event) => {});';
+      const result = helperHandlerCode.checkAndChangeAddEventListener(
+        'firewall',
+        'fetch',
+        code,
+      );
+      expect(result).toEqual({
+        matchEvent: true,
+        codeChanged: expectedCode,
+      });
+    });
+  });
+});

--- a/lib/utils/helperHandlerCode/index.js
+++ b/lib/utils/helperHandlerCode/index.js
@@ -1,0 +1,3 @@
+import helperHandlerCode from './helperHandlerCode.js';
+
+export default helperHandlerCode;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -19,6 +19,7 @@ import relocateImportsAndRequires from './relocateImportsAndRequires/index.js';
 import getExportedFunctionBody from './getExportedFunctionBody/index.js';
 import injectFilesInMem from './injectFilesInMem/index.js';
 import Manifest from './manifest/index.js';
+import helperHandlerCode from './helperHandlerCode/index.js';
 
 export {
   copyDirectory,
@@ -42,4 +43,5 @@ export {
   relocateImportsAndRequires,
   injectFilesInMem,
   Manifest,
+  helperHandlerCode,
 };

--- a/tests/e2e/simple-js-firewall-event.test.js
+++ b/tests/e2e/simple-js-firewall-event.test.js
@@ -1,0 +1,48 @@
+import { expect } from '@jest/globals';
+import supertest from 'supertest';
+import projectInitializer from '../utils/project-initializer.js';
+import projectStop from '../utils/project-stop.js';
+import { getContainerPort } from '../utils/docker-env-actions.js';
+
+// timeout in minutes
+const TIMEOUT = 1 * 60 * 1000;
+
+let serverPort;
+let localhostBaseUrl;
+const EXAMPLE_PATH = '/examples/simple-js-firewall-event';
+
+describe('E2E - simple-js-firewall-event project', () => {
+  let request;
+
+  beforeEach(async () => {
+    serverPort = getContainerPort();
+    localhostBaseUrl = `http://0.0.0.0:${serverPort}`;
+
+    request = supertest(localhostBaseUrl);
+
+    await projectInitializer(
+      EXAMPLE_PATH,
+      'javascript',
+      'compute',
+      serverPort,
+      false,
+      undefined,
+      true,
+    );
+  }, TIMEOUT);
+
+  afterEach(async () => {
+    await projectStop(serverPort, EXAMPLE_PATH.replace('/examples/', ''));
+  }, TIMEOUT);
+
+  test('should receive a 417 status code, the response headers and body message', async () => {
+    const response = await request
+      .get('/')
+      .expect(417)
+      .expect('Content-Type', /text\/plain/)
+      .expect('X-Fire-Status', 'On')
+      .expect('X-Fire-Type', 'Coal')
+      .expect('X-Country-Name', 'United States');
+    expect(response.text).toContain('The broccoli is burning.');
+  });
+});

--- a/tests/utils/project-initializer.js
+++ b/tests/utils/project-initializer.js
@@ -12,6 +12,7 @@ import {
  * @param {number} serverPort - port to use in vulcan server
  * @param {boolean} installPkgs - dependencies need to be installed?
  * @param {string} url - url test container
+ * @param {boolean} isFirewall - is firewall project
  */
 async function projectInitializer(
   examplePath,
@@ -20,6 +21,7 @@ async function projectInitializer(
   serverPort,
   installPkgs = true,
   url = 'http://localhost',
+  isFirewall = false,
 ) {
   const example = examplePath.replace('/examples/', '');
   const vulcanCmd =
@@ -32,13 +34,15 @@ async function projectInitializer(
 
   feedback.info(`[${example}] Building the project ...`);
   await execCommandInContainer(
-    `${vulcanCmd} build --preset ${preset} --mode ${mode}`,
+    `${vulcanCmd} build --preset ${preset} --mode ${mode} ${
+      isFirewall ? '--firewall' : ''
+    }`,
     examplePath,
   );
 
   feedback.info(`[${example}] Starting vulcan local server ...`);
   await execCommandInContainer(
-    `${vulcanCmd} dev -p ${serverPort}`,
+    `${vulcanCmd} dev -p ${serverPort} ${isFirewall ? '--firewall' : ''}`,
     examplePath,
     true,
   );


### PR DESCRIPTION
### (Experimental) Firewall Event API Local DEV

This feature aims to provide support for the firewall event API in the local environment and support when building firewall workers.

`For more details and how to run check out:
/examples/simple-js-firewall-event/README.md`

Example:

```js

addEventListener("firewall", (event) => {
  // https://www.azion.com/en/documentation/products/edge-application/edge-functions/runtime/api-reference/metadata/
  // In local development, the metadata is mocked.
  const { geoip_country_name } = event.request.metadata;

  event.addRequestHeader("X-Broccoli-Cooking-Method", "Boiling");
  event.addResponseHeader("X-Broccoli-Cooking-Method", "Barbecue");

  // event respondWith or event.deny must be called
  event.respondWith(
    new Response("The broccoli is burning.", {
      headers: {
        "X-Fire-Status": "On",
        "X-Fire-Type": "Coal",
        "X-Country-Name": geoip_country_name,
      },
      status: 417,
    })
  );

  // event.deny();
});

```


