### PR TITLE
feat: add support to network list api

### DIFF
--- a/examples/simple-js-network-list-with-firewall/README.md
+++ b/examples/simple-js-network-list-with-firewall/README.md
@@ -1,0 +1,72 @@
+# Simple js Network List with Firewall
+
+In this example we have a basic implementation of using the Network list with Firewall.
+
+### Usage:
+
+Run the build command:
+
+```bash
+
+vulcan build --firewall
+
+```
+
+Run the dev command:
+
+```bash
+
+vulcan dev --firewall
+
+```
+
+If everything goes as expected, the application runs successfully.
+
+```bash
+
+➜  simple-js-network-list-with-firewall vulcan dev --firewall
+[Vulcan] › ℹ  info      Using main.js as entrypoint...
+[Vulcan] [Build] › ℹ  info      Loading build context ...
+[Vulcan] [Build] › ℹ  info      Build without postbuild actions.
+[Vulcan] [Pre Build] › ℹ  info      Starting prebuild...
+[Vulcan] [Pre Build] › ✔  success   Prebuild succeeded!
+[Vulcan] [Build] › ℹ  info      Starting Vulcan build...
+[Vulcan] [Build] › ✔  success   Vulcan Build succeeded!
+[Vulcan] [Server] › ✔  success   Function running on port 0.0.0.0:3000, url: http://localhost:3000
+
+```
+
+Open in new terminal and execute the command:
+
+```bash
+
+curl -svk http://localhost:3000 -H "x-network-list-id: 1111"
+
+```
+
+The answer will be:
+
+```bash
+
+*   Trying [::1]:3000...
+* connect to ::1 port 3000 failed: Connection refused
+*   Trying 127.0.0.1:3000...
+* Connected to localhost (127.0.0.1) port 3000
+> GET / HTTP/1.1
+> Host: localhost:3000
+> User-Agent: curl/8.4.0
+> Accept: */*
+> x-network-list-id: 1111
+> 
+< HTTP/1.1 200 OK
+< content-type: text/plain;charset=UTF-8
+< x-azion-outcome: continue
+< Date: Fri, 01 Mar 2024 18:36:41 GMT
+< Connection: keep-alive
+< Keep-Alive: timeout=5
+< Transfer-Encoding: chunked
+< 
+* Connection #0 to host localhost left intact
+(mocked) continue to origin%
+
+```

--- a/examples/simple-js-network-list-with-firewall/azion.config.js
+++ b/examples/simple-js-network-list-with-firewall/azion.config.js
@@ -1,0 +1,9 @@
+export default {
+  networkList: [
+    {
+      id: 1111,
+      listType: "ip_cidr",
+      listContent: ["127.0.0.0/8"],
+    },
+  ],
+}

--- a/examples/simple-js-network-list-with-firewall/main.js
+++ b/examples/simple-js-network-list-with-firewall/main.js
@@ -1,0 +1,16 @@
+addEventListener("firewall", (event) => {
+  const network_list_id = event.request.headers.get("x-network-list-id");
+
+  // https://www.azion.com/en/documentation/products/edge-application/edge-functions/runtime/api-reference/metadata/
+  // In local development, the metadata is mocked.
+  const remote_addr = event.request.metadata["remote_addr"];
+  console.log(`Remote addr: ${remote_addr}`);
+
+  const found = Azion.networkList.contains(network_list_id, remote_addr);
+  console.log(`Found: ${found}`);
+
+  if (!found) {
+    return event.deny();
+  }
+  event.continue();
+});

--- a/examples/simple-js-network-list-with-firewall/package.json
+++ b/examples/simple-js-network-list-with-firewall/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "simple-js-network-list-with-firewall",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "aziontech",
+  "license": "ISC"
+}

--- a/examples/simple-js-network-list-with-firewall/vulcan.config.js
+++ b/examples/simple-js-network-list-with-firewall/vulcan.config.js
@@ -1,0 +1,9 @@
+export default {
+  builder: "esbuild",
+  entry: "main.js",
+  preset: {
+    name: "javascript",
+    mode: "compute",
+  },
+  useOwnWorker: true,
+};

--- a/examples/simple-js-network-list/README.md
+++ b/examples/simple-js-network-list/README.md
@@ -1,0 +1,74 @@
+# Simple js Network List
+
+In this example we have a basic implementation of using the Network list.
+
+### Usage:
+
+Run the build command:
+
+```bash
+
+vulcan build
+
+```
+
+Run the dev command:
+
+```bash
+
+vulcan dev
+
+```
+
+If everything goes as expected, the application runs successfully.
+
+```bash
+
+➜  simple-js-network-list vulcan dev
+[Vulcan] › ℹ  info      Using main.js as entrypoint...
+[Vulcan] [Build] › ℹ  info      Loading build context ...
+[Vulcan] [Build] › ℹ  info      Build without postbuild actions.
+[Vulcan] [Pre Build] › ℹ  info      Starting prebuild...
+[Vulcan] [Pre Build] › ✔  success   Prebuild succeeded!
+[Vulcan] [Build] › ℹ  info      Starting Vulcan build...
+[Vulcan] [Build] › ✔  success   Vulcan Build succeeded!
+[Vulcan] [Server] › ✔  success   Function running on port 0.0.0.0:3000, url: http://localhost:3000
+
+```
+
+Open in new terminal and execute the command:
+
+```bash
+
+curl -svk http://localhost:3000 -H "x-network-list-id: 1111" -H "x-element: 10.0.0.1"
+
+```
+
+The answer will be:
+
+```bash
+
+curl -svk http://localhost:3000 -H "x-network-list-id: 1111" -H "x-element: 10.0.0.1"
+*   Trying [::1]:3000...
+* connect to ::1 port 3000 failed: Connection refused
+*   Trying 127.0.0.1:3000...
+* Connected to localhost (127.0.0.1) port 3000
+> GET / HTTP/1.1
+> Host: localhost:3000
+> User-Agent: curl/8.4.0
+> Accept: */*
+> x-network-list-id: 1111
+> x-element: 10.0.0.1
+>
+< HTTP/1.1 200 OK
+< content-type: text/plain;charset=UTF-8
+< x-element: 10.0.0.1
+< x-presence: present # value present
+< Date: Mon, 04 Mar 2024 12:37:56 GMT
+< Connection: keep-alive
+< Keep-Alive: timeout=5
+< Transfer-Encoding: chunked
+<
+* Connection #0 to host localhost left intact
+
+```

--- a/examples/simple-js-network-list/azion.config.js
+++ b/examples/simple-js-network-list/azion.config.js
@@ -1,0 +1,9 @@
+export default {
+  networkList: [
+    {
+      id: 1111,
+      listType: "ip_cidr",
+      listContent: ["127.0.0.0/8", "10.0.0.1"],
+    },
+  ],
+}

--- a/examples/simple-js-network-list/main.js
+++ b/examples/simple-js-network-list/main.js
@@ -1,0 +1,24 @@
+export default async function main(event) {
+    const request = event.request;
+    if (
+      !request.headers.get("x-network-list-id") ||
+      !request.headers.get("x-element")
+    ) {
+      return new Response("Missing headers", { status: 400 });
+    }
+  
+    let network_list_id = request.headers.get("x-network-list-id");
+    let element = request.headers.get("x-element");
+  
+    let response_headers = new Headers();
+    response_headers.set("X-Element", element);
+  
+    if (Azion.networkList.contains(network_list_id, element)) {
+      response_headers.set("X-Presence", "present");
+    } else {
+      response_headers.set("X-Presence", "absent");
+    }
+  
+    return new Response("", { headers: response_headers });
+  }
+  

--- a/examples/simple-js-network-list/package.json
+++ b/examples/simple-js-network-list/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "simple-js-network-list",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "aziontech",
+  "license": "ISC"
+}

--- a/examples/simple-js-network-list/vulcan.config.js
+++ b/examples/simple-js-network-list/vulcan.config.js
@@ -1,0 +1,8 @@
+export default {
+  builder: "esbuild",
+  entry: "main.js",
+  preset: {
+    name: "javascript",
+    mode: "compute",
+  },
+};

--- a/lib/build/bundlers/polyfills/polyfills-manager.js
+++ b/lib/build/bundlers/polyfills/polyfills-manager.js
@@ -161,8 +161,12 @@ class PolyfillsManager {
 
     // globalThis.Azion
     this.setExternal(
-      'Azion',
+      'Azion.env',
       `${externalPolyfillsPath}/azion/env-vars/env-vars.polyfills.js`,
+    );
+    this.setExternal(
+      'Azion.networkList',
+      `${externalPolyfillsPath}/azion/network-list/network-list.polyfills.js`,
     );
 
     return {

--- a/lib/env/polyfills/azion/network-list/context/index.js
+++ b/lib/env/polyfills/azion/network-list/context/index.js
@@ -1,0 +1,3 @@
+import NetworkListContext from './network-list.context.js';
+
+export default NetworkListContext;

--- a/lib/env/polyfills/azion/network-list/context/network-list.context.js
+++ b/lib/env/polyfills/azion/network-list/context/network-list.context.js
@@ -1,0 +1,137 @@
+import ipLib from 'ip';
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * This class is a VM context (NETWORK_LIST_CONTEXT) to handle with network list
+ * @class NetworkListContext
+ * @description Class to manage the network list
+ */
+class NetworkListContext {
+  /**
+   * Cache Import file flag - If true, the file will be reloaded every time default: true
+   */
+  #cacheImportFile;
+
+  #networkList = [];
+
+  #configFile = 'azion.config.js';
+
+  /**
+   * Creates an instance of NetworkListContext.
+   * @param {boolean} [cacheImportFile=true] - Cache Import file flag - If true, the file will be reloaded every time default: true
+   */
+  constructor(cacheImportFile = true) {
+    this.#cacheImportFile = cacheImportFile;
+    this.#init();
+  }
+
+  /**
+   * Check if the network list contains the value
+   * @param {string} networkListId - The network list id
+   * @param {string} value - The value to check
+   * @returns {boolean} - Return true if the network list contains the value
+   * @memberof NetworkListContext
+   */
+  contains(networkListId, value) {
+    const network = this.#networkList.find(
+      (networkItem) =>
+        parseInt(networkItem.id, 10) === parseInt(networkListId, 10),
+    );
+    return this.#containsType(network, value);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async #init() {
+    try {
+      const config = await this.#loadConfigFile();
+      this.#networkList = config.networkList;
+    } catch (error) {
+      this.#networkList = [];
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async #loadConfigFile() {
+    const projectRoot = process.cwd();
+    const isWindows = process.platform === 'win32';
+    const outputPath = isWindows
+      ? fileURLToPath(new URL(`file:///${join(projectRoot, '.')}`))
+      : join(projectRoot, '.');
+    const configFilePath = join(outputPath, this.#configFile);
+
+    const typeImport = this.#checkFileImportType(configFilePath);
+    if (typeImport === 'esm') {
+      const pathCache = this.#cacheImportFile ? `?u=${Date.now()}` : '';
+      const config = (await import(`${configFilePath}${pathCache}`)).default;
+      return config;
+    }
+    // cjs import
+    if (this.#cacheImportFile) {
+      delete require.cache[configFilePath];
+    }
+    const config = await new Promise((resolve) => {
+      // eslint-disable-next-line import/no-dynamic-require, no-promise-executor-return
+      return resolve(require(`${configFilePath}`));
+    });
+    return config?.default || config;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #checkFileImportType(configFilePath) {
+    const file = readFileSync(configFilePath, 'utf8');
+    if (file?.includes('export default')) {
+      return 'esm';
+    }
+    return 'cjs';
+  }
+
+  #containsType(network, value) {
+    switch (network?.listType) {
+      case 'ip_cidr':
+        return this.#networkCIDR(value, network);
+      case 'asn':
+        return this.#networkAsn(value, network);
+      case 'countries':
+        return this.#networkCountries(value, network);
+      default:
+        return false;
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #networkCIDR(ipAddress, network) {
+    const listContent = network?.listContent;
+    if (!listContent || listContent.length === 0) return false;
+    return listContent.some((currentIp) => {
+      if (currentIp.includes('/')) {
+        return ipLib.cidrSubnet(currentIp).contains(ipAddress);
+      }
+      return currentIp === ipAddress;
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #networkAsn(asn, network) {
+    const listContent = network?.listContent;
+    if (!listContent || listContent.length === 0) return false;
+    return listContent.some((currentAsn) => {
+      return parseInt(currentAsn, 10) === parseInt(asn, 10);
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #networkCountries(country, network) {
+    const listContent = network?.listContent;
+    if (!listContent || listContent.length === 0) return false;
+    return listContent.some((currentCountry) => {
+      return currentCountry === country;
+    });
+  }
+}
+
+export default NetworkListContext;

--- a/lib/env/polyfills/azion/network-list/context/network-list.context.js
+++ b/lib/env/polyfills/azion/network-list/context/network-list.context.js
@@ -1,6 +1,6 @@
 import ipLib from 'ip';
-import { join } from 'node:path';
-import { readFileSync } from 'node:fs';
+import nodePath from 'node:path';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
@@ -13,20 +13,22 @@ const require = createRequire(import.meta.url);
  */
 class NetworkListContext {
   /**
-   * Cache Import file flag - If true, the file will be reloaded every time default: true
+   * Cache Dynamic Import flag - If true, the file will be reloaded every time default: true
    */
-  #cacheImportFile;
+  #cacheDynamicImport;
 
   #networkList = [];
+
+  #workDir = '.edge';
 
   #configFile = 'azion.config.js';
 
   /**
    * Creates an instance of NetworkListContext.
-   * @param {boolean} [cacheImportFile=true] - Cache Import file flag - If true, the file will be reloaded every time default: true
+   * @param {boolean} [cacheDynamicImport=true] - Cache Dynamic Import flag - If false, the file will be reloaded every time default: true
    */
-  constructor(cacheImportFile = true) {
-    this.#cacheImportFile = cacheImportFile;
+  constructor(cacheDynamicImport = true) {
+    this.#cacheDynamicImport = cacheDynamicImport;
     this.#init();
   }
 
@@ -43,51 +45,6 @@ class NetworkListContext {
         parseInt(networkItem.id, 10) === parseInt(networkListId, 10),
     );
     return this.#containsType(network, value);
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  async #init() {
-    try {
-      const config = await this.#loadConfigFile();
-      this.#networkList = config.networkList;
-    } catch (error) {
-      this.#networkList = [];
-    }
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  async #loadConfigFile() {
-    const projectRoot = process.cwd();
-    const isWindows = process.platform === 'win32';
-    const outputPath = isWindows
-      ? fileURLToPath(new URL(`file:///${join(projectRoot, '.')}`))
-      : join(projectRoot, '.');
-    const configFilePath = join(outputPath, this.#configFile);
-
-    const typeImport = this.#checkFileImportType(configFilePath);
-    if (typeImport === 'esm') {
-      const pathCache = this.#cacheImportFile ? `?u=${Date.now()}` : '';
-      const config = (await import(`${configFilePath}${pathCache}`)).default;
-      return config;
-    }
-    // cjs import
-    if (this.#cacheImportFile) {
-      delete require.cache[configFilePath];
-    }
-    const config = await new Promise((resolve) => {
-      // eslint-disable-next-line import/no-dynamic-require, no-promise-executor-return
-      return resolve(require(`${configFilePath}`));
-    });
-    return config?.default || config;
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  #checkFileImportType(configFilePath) {
-    const file = readFileSync(configFilePath, 'utf8');
-    if (file?.includes('export default')) {
-      return 'esm';
-    }
-    return 'cjs';
   }
 
   #containsType(network, value) {
@@ -131,6 +88,144 @@ class NetworkListContext {
     return listContent.some((currentCountry) => {
       return currentCountry === country;
     });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async #init() {
+    try {
+      const config = await this.#loadConfigFile();
+      this.#networkList = config.networkList;
+    } catch (error) {
+      this.#networkList = [];
+    }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async #loadConfigFile() {
+    const { configFilePath, rootPath } = this.#getConfigFilePath();
+
+    const {
+      type: typeImport,
+      changed,
+      currentConfigPath,
+      matchPaths,
+    } = this.#checkFileImportType(configFilePath);
+
+    let config;
+    if (typeImport === 'esm') {
+      config = await this.#importEsmModule(
+        rootPath,
+        currentConfigPath,
+        changed,
+      );
+    } else {
+      config = await this.#importCjsModule(
+        rootPath,
+        currentConfigPath,
+        changed,
+        matchPaths,
+      );
+    }
+
+    return config?.default || config;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #getConfigFilePath() {
+    const projectRoot = process.cwd();
+    const isWindows = process.platform === 'win32';
+    const rootPath = isWindows
+      ? fileURLToPath(new URL(`file:///${nodePath.resolve(projectRoot, '.')}`))
+      : nodePath.resolve(projectRoot, '.');
+    return {
+      configFilePath: nodePath.resolve(rootPath, this.#configFile),
+      rootPath,
+    };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async #importEsmModule(rootPath, originalConfigPath, changed) {
+    let pathCache = originalConfigPath;
+    if (!this.#cacheDynamicImport) {
+      pathCache = `${originalConfigPath}?u=${Date.now()}`;
+    }
+    const config = (await import(pathCache)).default;
+    if (changed) {
+      rmSync(originalConfigPath);
+    }
+    return config;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async #importCjsModule(rootPath, configFilePath, changed, matchPaths) {
+    if (!this.#cacheDynamicImport) {
+      delete require.cache[configFilePath];
+      if (changed && matchPaths?.length > 0) {
+        matchPaths.forEach((match) => {
+          delete require.cache[nodePath.resolve(rootPath, match)];
+        });
+      }
+    }
+    return new Promise((resolve) => {
+      // eslint-disable-next-line import/no-dynamic-require
+      resolve(require(configFilePath));
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #checkFileImportType(originalConfigPath) {
+    const file = readFileSync(originalConfigPath, 'utf8');
+    if (file?.includes('export default')) {
+      const { changed, currentConfigPath } = this.#changeEsmImports(
+        originalConfigPath,
+        file,
+      );
+      return { type: 'esm', changed, currentConfigPath };
+    }
+    const { changed, matchPaths } = this.#changeCjsImports(file);
+    return {
+      type: 'cjs',
+      changed,
+      currentConfigPath: originalConfigPath,
+      matchPaths,
+    };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #changeEsmImports(originalConfigPath, file) {
+    const regex = /import\s+(.*)\s+from\s+['"]\.(.*)['"]/g;
+    let changed = false;
+    let fileUpdated = file;
+    if (file.match(regex)) {
+      changed = true;
+      fileUpdated = file.replace(
+        regex,
+        `import $1 from "..$2?u=${Date.now()}"`,
+      );
+      const tmpFile = this.#configFile.replace('.js', '.temp.js');
+      const tmpConfigPath = nodePath.join(
+        process.cwd(),
+        this.#workDir,
+        tmpFile,
+      );
+      writeFileSync(tmpConfigPath, fileUpdated, 'utf8');
+      return { changed, currentConfigPath: tmpConfigPath };
+    }
+    return { changed, currentConfigPath: originalConfigPath };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #changeCjsImports(file) {
+    let changed = false;
+    const regex = /require\(['"]([^'"]+)['"]\)/g;
+    const matchPaths = [];
+    let match = regex.exec(file);
+    while (match !== null) {
+      changed = true;
+      matchPaths.push(match[1]);
+      match = regex.exec(file);
+    }
+    return { changed, matchPaths };
   }
 }
 

--- a/lib/env/polyfills/azion/network-list/context/network-list.context.test.js
+++ b/lib/env/polyfills/azion/network-list/context/network-list.context.test.js
@@ -1,0 +1,44 @@
+import { it } from '@jest/globals';
+import mockFs from 'mock-fs';
+import NetworkListContext from './network-list.context.js';
+
+describe('Network List Context', () => {
+  let networkListContext;
+
+  beforeEach(async () => {
+    // eslint-disable-next-line jest/no-standalone-expect
+    const typeImport = expect.getState().currentTestName.includes('commonjs')
+      ? 'module.exports ='
+      : 'export default';
+    const code = `${typeImport} {
+        networkList:  [
+            { id: 1, listType: "ip_cidr", listContent: ["10.0.0.1"] },
+            { id: 2, listType: "asn", listContent: [123, 456, 789]},
+            { id: 3, listType: "countries", listContent: ["United States", "Brazil"]}
+        ]};`;
+    mockFs({
+      'azion.config.js': code,
+    });
+    networkListContext = new NetworkListContext(false);
+  });
+
+  afterEach(() => {
+    mockFs.restore();
+  });
+
+  it('should contain the valid ip in the network list and list type is ip_cidr', async () => {
+    expect(networkListContext.contains(1, '10.0.0.1')).toBe(true);
+  });
+
+  it('should contain the valid asn in the network list and list type is asn', async () => {
+    expect(networkListContext.contains(2, 123)).toBe(true);
+  });
+
+  it('should contain the valid country in the network list and list type is countries', async () => {
+    expect(networkListContext.contains(3, 'United States')).toBe(true);
+  });
+
+  it('should type import be commonjs and contain the valid ip in the network list and list type is ip_cidr', async () => {
+    expect(networkListContext.contains(1, '10.0.0.1')).toBe(true);
+  });
+});

--- a/lib/env/polyfills/azion/network-list/context/network-list.context.test.js
+++ b/lib/env/polyfills/azion/network-list/context/network-list.context.test.js
@@ -19,7 +19,7 @@ describe('Network List Context', () => {
     mockFs({
       'azion.config.js': code,
     });
-    networkListContext = new NetworkListContext(false);
+    networkListContext = new NetworkListContext();
   });
 
   afterEach(() => {

--- a/lib/env/polyfills/azion/network-list/index.js
+++ b/lib/env/polyfills/azion/network-list/index.js
@@ -1,0 +1,3 @@
+import NetworkListContext from './context/index.js';
+
+export default NetworkListContext;

--- a/lib/env/polyfills/azion/network-list/network-list.polyfills.js
+++ b/lib/env/polyfills/azion/network-list/network-list.polyfills.js
@@ -1,0 +1,16 @@
+/* eslint-disable */
+globalThis.Azion = globalThis.Azion || {};
+
+globalThis.Azion.networkList = {};
+// unique context for each instance
+const instanceNetworkList = new NETWORK_LIST_CONTEXT();
+
+/**
+ *
+ * @param {string} network_list_id - The network list id
+ * @param {string} value - The value to check
+ * @returns
+ */
+globalThis.Azion.networkList.contains = (network_list_id, value) => {
+  return instanceNetworkList.contains(network_list_id, value);
+};

--- a/lib/env/polyfills/azion/network-list/network-list.polyfills.js
+++ b/lib/env/polyfills/azion/network-list/network-list.polyfills.js
@@ -3,7 +3,7 @@ globalThis.Azion = globalThis.Azion || {};
 
 globalThis.Azion.networkList = {};
 // unique context for each instance
-const instanceNetworkList = new NETWORK_LIST_CONTEXT();
+const instanceNetworkList = new NETWORK_LIST_CONTEXT(false);
 
 /**
  *

--- a/lib/env/polyfills/index.js
+++ b/lib/env/polyfills/index.js
@@ -3,6 +3,7 @@ import FetchEventContext from './azion/fetch-event/index.js';
 import { AsyncHooksContext } from './async-hooks/index.js';
 import { StorageContext } from './azion/storage/index.js';
 import EnvVarsContext from './azion/env-vars/index.js';
+import NetworkListContext from './azion/network-list/index.js';
 
 export {
   fetchContext,
@@ -10,4 +11,5 @@ export {
   AsyncHooksContext,
   StorageContext,
   EnvVarsContext,
+  NetworkListContext,
 };

--- a/lib/env/runtime.env.js
+++ b/lib/env/runtime.env.js
@@ -6,6 +6,7 @@ import {
   AsyncHooksContext,
   StorageContext,
   EnvVarsContext,
+  NetworkListContext,
 } from './polyfills/index.js';
 import FirewallEventContext from './polyfills/azion/firewall-event/index.js';
 
@@ -76,6 +77,9 @@ function runtime(code, isFirewallEvent = false) {
 
     // EnvVars Context
     context.ENV_VARS_CONTEXT = EnvVarsContext;
+
+    // Network List Context
+    context.NETWORK_LIST_CONTEXT = NetworkListContext;
 
     return context;
   };

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "https-browserify": "^1.0.0",
     "inquirer": "^9.2.7",
     "install": "^0.13.0",
+    "ip": "^2.0.1",
     "lodash": "^4.17.21",
     "lodash.merge": "^4.6.2",
     "log-update": "^5.0.1",

--- a/tests/e2e/simple-js-network-list-with-firewall.test.js
+++ b/tests/e2e/simple-js-network-list-with-firewall.test.js
@@ -1,0 +1,47 @@
+import { expect } from '@jest/globals';
+import supertest from 'supertest';
+import projectInitializer from '../utils/project-initializer.js';
+import projectStop from '../utils/project-stop.js';
+import { getContainerPort } from '../utils/docker-env-actions.js';
+
+// timeout in minutes
+const TIMEOUT = 1 * 60 * 1000;
+
+let serverPort;
+let localhostBaseUrl;
+const EXAMPLE_PATH = '/examples/simple-js-network-list-with-firewall';
+
+describe('E2E - simple-js-network-list-with-firewall project', () => {
+  let request;
+
+  beforeEach(async () => {
+    serverPort = getContainerPort();
+    localhostBaseUrl = `http://0.0.0.0:${serverPort}`;
+
+    request = supertest(localhostBaseUrl);
+
+    await projectInitializer(
+      EXAMPLE_PATH,
+      'javascript',
+      'compute',
+      serverPort,
+      false,
+      undefined,
+      true,
+    );
+  }, TIMEOUT);
+
+  afterEach(async () => {
+    await projectStop(serverPort, EXAMPLE_PATH.replace('/examples/', ''));
+  }, TIMEOUT);
+
+  test('should return 200 and the response header x-azion-outcome with the value continue', async () => {
+    const response = await request
+      .get('/')
+      .set('x-network-list-id', '1111')
+      .expect(200)
+      .expect('x-azion-outcome', 'continue');
+
+    expect(response.text).toContain('continue to origin');
+  });
+});

--- a/tests/e2e/simple-js-network-list.test.js
+++ b/tests/e2e/simple-js-network-list.test.js
@@ -1,0 +1,56 @@
+import { test } from '@jest/globals';
+import supertest from 'supertest';
+import projectInitializer from '../utils/project-initializer.js';
+import projectStop from '../utils/project-stop.js';
+import { getContainerPort } from '../utils/docker-env-actions.js';
+
+// timeout in minutes
+const TIMEOUT = 1 * 60 * 1000;
+
+let serverPort;
+let localhostBaseUrl;
+const EXAMPLE_PATH = '/examples/simple-js-network-list';
+
+describe('E2E - simple-js-network-list project', () => {
+  let request;
+
+  beforeEach(async () => {
+    serverPort = getContainerPort();
+    localhostBaseUrl = `http://0.0.0.0:${serverPort}`;
+
+    request = supertest(localhostBaseUrl);
+
+    await projectInitializer(
+      EXAMPLE_PATH,
+      'javascript',
+      'compute',
+      serverPort,
+      false,
+      undefined,
+    );
+  }, TIMEOUT);
+
+  afterEach(async () => {
+    await projectStop(serverPort, EXAMPLE_PATH.replace('/examples/', ''));
+  }, TIMEOUT);
+
+  test('should return 200 and the response header x-presence with the value present', async () => {
+    const response = await request
+      .get('/')
+      .set('x-network-list-id', '1111')
+      .set('x-element', '10.0.0.1')
+      .expect(200);
+
+    expect(response.headers['x-presence']).toBe('present');
+  });
+
+  test('should return 403 and the response header x-presence with the value absent', async () => {
+    const response = await request
+      .get('/')
+      .set('x-network-list-id', '1111')
+      .set('x-element', '10.0.0.3')
+      .expect(200);
+
+    expect(response.headers['x-presence']).toBe('absent');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4990,6 +4990,11 @@ ip@^2.0.0:
   resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
   integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
 
+ip@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.1.tgz#e8f3595d33a3ea66490204234b77636965307105"
+  integrity sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==
+
 is-arguments@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"


### PR DESCRIPTION
### Feature Network List

This feature supports Azion Network List in the local dev environment, which reads the file azion.config.js which must contain networks.

#### Adding two usage examples which are located at:

- /examples/simple-js-network-list
- /examples/simple-js-network-list-with-firewall

_Important: For more usage details, please visit the examples README._

```js

export default async function main(event) {
    const request = event.request;
    if (
      !request.headers.get("x-network-list-id") ||
      !request.headers.get("x-element")
    ) {
      return new Response("Missing headers", { status: 400 });
    }
  
    let network_list_id = request.headers.get("x-network-list-id");
    let element = request.headers.get("x-element");
  
    let response_headers = new Headers();
    response_headers.set("X-Element", element);
  
    if (Azion.networkList.contains(network_list_id, element)) {
      response_headers.set("X-Presence", "present");
    } else {
      response_headers.set("X-Presence", "absent");
    }
  
    return new Response("", { headers: response_headers });
}
  
  
```
