### PR TITLE
fix: priority in build command options

### DIFF
--- a/lib/commands/build.commands.js
+++ b/lib/commands/build.commands.js
@@ -4,7 +4,7 @@ import vulcan from '../env/vulcan.env.js';
 
 /**
  * Retrieves a configuration value based on priority.
- * Priority order: customConfig, inputOption, vulcanVariable, defaultValue.
+ * Priority order: inputOption, customConfig, vulcanVariable, defaultValue.
  * @param {any} customConfig - Configuration from custom module.
  * @param {any} inputOption - Configuration provided as input.
  * @param {any} vulcanVariable - Configuration from the .vulcan file.
@@ -17,7 +17,7 @@ function getConfigValue(
   vulcanVariable,
   defaultValue,
 ) {
-  return customConfig ?? inputOption ?? vulcanVariable ?? defaultValue;
+  return inputOption ?? customConfig ?? vulcanVariable ?? defaultValue;
 }
 /**
  * Retrieves a preset configuration value based on priority.

--- a/lib/main.js
+++ b/lib/main.js
@@ -83,9 +83,9 @@ function startVulcanProgram() {
       'Preset of build target (e.g., vue, next, javascript)',
     )
     .option('--mode <type>', 'Mode of build target (e.g., deliver, compute)')
-    .option('--useNodePolyfills', 'Use node polyfills in build.')
+    .option('--useNodePolyfills <boolean>', 'Use node polyfills in build.')
     .option(
-      '--useOwnWorker',
+      '--useOwnWorker <boolean>',
       'This flag indicates that the constructed code inserts its own worker expression, such as addEventListener("fetch") or similar, without the need to inject a provider.',
     )
     .option(


### PR DESCRIPTION
In the build command, when the --useNodePolyfills true | false, --useOwnWorker true| false was prioritized over other configuration options (vulcan.config.js, .vulcan and preset config).

#### To test:

This is available in any preset for testing we will use /examples/simple-js-esm.

```bash

vulcan build --preset javascript --mode compute

```

With the command above, the .vulcan will be generated, and it will contain useNodePolyfills false. To change via command option, execute below:

```bash

vulcan build --preset javascript --mode compute --useNodePolyfills true

```