### PR TITLE
fix: webpack config when ts loader

### DIFF
--- a/lib/build/bundlers/webpack/webpack.config.js
+++ b/lib/build/bundlers/webpack/webpack.config.js
@@ -2,6 +2,7 @@ import webpack from 'webpack';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
+import fs from 'fs';
 
 const require = createRequire(import.meta.url);
 
@@ -10,6 +11,44 @@ const isWindows = process.platform === 'win32';
 const outputPath = isWindows
   ? fileURLToPath(new URL(`file:///${join(projectRoot, '.edge')}`))
   : join(projectRoot, '.edge');
+
+const fileExists = (filePath) => {
+  try {
+    return fs.existsSync(filePath);
+  } catch (err) {
+    return false;
+  }
+};
+
+/**
+ * Define the loader typescript rules if the tsconfig.json file exists
+ * @returns {import('webpack').Configuration} - Module rules
+ */
+const defineLoaderTypescriptRules = () => {
+  const tsConfigPath = join(projectRoot, 'tsconfig.json');
+  const tsConfigExist = fileExists(tsConfigPath);
+  if (tsConfigExist) {
+    return {
+      module: {
+        rules: [
+          {
+            test: /\.ts?$/,
+            use: [
+              {
+                loader: require.resolve('ts-loader'),
+                options: {
+                  transpileOnly: true,
+                },
+              },
+            ],
+            exclude: /node_modules/,
+          },
+        ],
+      },
+    };
+  }
+  return { module: {} };
+};
 
 export default {
   experiments: {
@@ -25,22 +64,7 @@ export default {
     mainFields: ['browser', 'main', 'module'],
   },
   // loaders
-  module: {
-    rules: [
-      {
-        test: /\.ts?$/,
-        use: [
-          {
-            loader: require.resolve('ts-loader'),
-            options: {
-              transpileOnly: true,
-            },
-          },
-        ],
-        exclude: /node_modules/,
-      },
-    ],
-  },
+  ...defineLoaderTypescriptRules(),
   mode: 'production',
   target: ['webworker', 'es2022'],
   plugins: [

--- a/lib/presets/custom/rustwasm/compute/prebuild.js
+++ b/lib/presets/custom/rustwasm/compute/prebuild.js
@@ -7,7 +7,7 @@ const manifest = {
       {
         match: '^\\/',
         runFunction: {
-          target: '.edge/worker.js',
+          path: '.edge/worker.js',
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
     "prettier": "^3.0.3",
     "puppeteer": "^21.5.0",
     "supertest": "^6.3.3",
-    "tmp": "^0.2.1"
+    "tmp": "^0.2.1",
+    "typescript": "^5.4.2"
   },
   "imports": {
     "#root/*": "./",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4997,12 +4997,7 @@ ip@^1.1.8:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.9.tgz#8dfbcc99a754d07f425310b86a99546b1151e396"
   integrity sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==
 
-ip@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.1.tgz#e8f3595d33a3ea66490204234b77636965307105"
-  integrity sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==
-
-ip@^2.0.1:
+ip@^2.0.0, ip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.1.tgz#e8f3595d33a3ea66490204234b77636965307105"
   integrity sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==
@@ -8967,6 +8962,11 @@ typed-array-length@^1.0.4:
     call-bind "^1.0.2"
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
+
+typescript@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
### Fix

When tsconfg.json does not exist in the typescript project ts-loader rule is ignored.
This occurred in the rust preset that uses webpack and contains files .ts in your build.

### Bonus

Changing the manifest generation from target to path.