### PR TITLE
feat: adding the origin configuration to the manifest

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ yarn.lock
 CHANGELOG.md
 docker-compose.yml
 CODEOWNERS
+README.md

--- a/lib/presets/custom/angular/deliver/prebuild.js
+++ b/lib/presets/custom/angular/deliver/prebuild.js
@@ -5,11 +5,18 @@ import fs from 'fs-extra';
 const packageManager = await getPackageManager();
 
 const manifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '^\\/',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
       },

--- a/lib/presets/custom/astro/deliver/prebuild.js
+++ b/lib/presets/custom/astro/deliver/prebuild.js
@@ -9,11 +9,18 @@ import {
 const packageManager = await getPackageManager();
 
 const manifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '^\\/',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
       },

--- a/lib/presets/custom/eleventy/deliver/prebuild.js
+++ b/lib/presets/custom/eleventy/deliver/prebuild.js
@@ -2,11 +2,18 @@ import { rm } from 'fs/promises';
 import { exec, copyDirectory, generateManifest } from '#utils';
 
 const manifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '^\\/',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
       },

--- a/lib/presets/custom/gatsby/deliver/prebuild.js
+++ b/lib/presets/custom/gatsby/deliver/prebuild.js
@@ -9,11 +9,18 @@ import {
 const packageManager = await getPackageManager();
 
 const manifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '^\\/',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
       },

--- a/lib/presets/custom/hexo/deliver/prebuild.js
+++ b/lib/presets/custom/hexo/deliver/prebuild.js
@@ -9,11 +9,18 @@ import {
 const packageManager = await getPackageManager();
 
 const manifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '^\\/',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
       },

--- a/lib/presets/custom/hugo/deliver/prebuild.js
+++ b/lib/presets/custom/hugo/deliver/prebuild.js
@@ -9,11 +9,18 @@ import {
 const packageManager = await getPackageManager();
 
 const manifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '^\\/',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
       },

--- a/lib/presets/custom/next/compute/prebuild.js
+++ b/lib/presets/custom/next/compute/prebuild.js
@@ -12,11 +12,18 @@ const { deleteTelemetryFiles, createVercelProjectConfig, runVercelBuild } =
   VercelUtils;
 
 const edgeManifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '/^/_next/static/;', // starts with '/_next/static/'
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
         deliver: true,
@@ -24,6 +31,7 @@ const edgeManifest = {
       {
         match: '.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4)$',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
         deliver: true,

--- a/lib/presets/custom/next/deliver/prebuild.js
+++ b/lib/presets/custom/next/deliver/prebuild.js
@@ -15,11 +15,18 @@ import { getNextConfig, readManifestFile } from '../utils.next.js';
 const packageManager = await getPackageManager();
 
 const cdnManifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '^\\/',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
       },

--- a/lib/presets/custom/react/deliver/prebuild.js
+++ b/lib/presets/custom/react/deliver/prebuild.js
@@ -3,11 +3,18 @@ import { exec, getPackageManager, generateManifest } from '#utils';
 const packageManager = await getPackageManager();
 
 const manifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '^\\/',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
       },

--- a/lib/presets/custom/vue/deliver/prebuild.js
+++ b/lib/presets/custom/vue/deliver/prebuild.js
@@ -11,11 +11,18 @@ const edgeStorageDir = '.edge/storage';
 const defaultViteOutDir = 'dist';
 
 const manifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '^\\/',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
       },

--- a/lib/presets/default/html/deliver/prebuild.js
+++ b/lib/presets/default/html/deliver/prebuild.js
@@ -1,11 +1,18 @@
 import { generateManifest } from '#utils';
 
 const manifest = {
+  origin: [
+    {
+      name: 'origin_storage_default',
+      type: 'object_storage',
+    },
+  ],
   rules: {
     request: [
       {
         match: '^\\/',
         setOrigin: {
+          name: 'origin_storage_default',
           type: 'object_storage',
         },
       },

--- a/lib/utils/generateManifest/fixtures/azion.config.js
+++ b/lib/utils/generateManifest/fixtures/azion.config.js
@@ -1,4 +1,12 @@
 export default {
+  origin: [
+    {
+      name: 'myneworigin',
+      type: 'object_storage',
+      bucket: 'blue-courage',
+      prefix: '0101010101001',
+    },
+  ],
   cache: [
     {
       name: 'mycache',

--- a/lib/utils/generateManifest/fixtures/azion.config.js
+++ b/lib/utils/generateManifest/fixtures/azion.config.js
@@ -42,7 +42,7 @@ export default {
         name: 'name2',
         match: '/^/_statics/;', // start with /_statics
         setOrigin: {
-          name: 'name',
+          name: 'myneworigin',
           type: 'object_storage',
         },
         deliver: true,

--- a/lib/utils/generateManifest/fixtures/schema.js
+++ b/lib/utils/generateManifest/fixtures/schema.js
@@ -1,6 +1,52 @@
 const azionConfigSchema = {
   type: 'object',
   properties: {
+    origin: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            errorMessage: "The 'name' field must be a string.",
+          },
+          type: {
+            type: 'string',
+            errorMessage: "The 'type' field must be a string.",
+          },
+          bucket: {
+            type: ['string', 'null'],
+            errorMessage: "The 'bucket' field must be a string or null.",
+          },
+          prefix: {
+            type: ['string', 'null'],
+            errorMessage: "The 'prefix' field must be a string or null.",
+          },
+          addresses: {
+            type: 'array',
+            items: {
+              type: 'string',
+              errorMessage: "The 'address' field must be a string.",
+            },
+          },
+          hostHeader: {
+            type: 'string',
+            errorMessage: "The 'hostHeader' field must be a string.",
+          },
+        },
+        required: ['name', 'type'],
+        additionalProperties: false,
+        errorMessage: {
+          additionalProperties:
+            'No additional properties are allowed in origin item objects.',
+          required:
+            "The 'name and type' field is required in each origin item.",
+        },
+      },
+      errorMessage: {
+        additionalProperties: "The 'origin' field must be an array of objects.",
+      },
+    },
     cache: {
       type: 'array',
       items: {
@@ -132,18 +178,8 @@ const azionConfigSchema = {
                     type: 'string',
                     errorMessage: "The 'type' field must be a string.",
                   },
-                  bucket: {
-                    type: ['string', 'null'],
-                    errorMessage:
-                      "The 'bucket' field must be a string or null.",
-                  },
-                  prefix: {
-                    type: ['string', 'null'],
-                    errorMessage:
-                      "The 'prefix' field must be a string or null.",
-                  },
                 },
-                required: ['type'],
+                required: ['name', 'type'],
                 additionalProperties: false,
                 errorMessage: {
                   additionalProperties:

--- a/lib/utils/generateManifest/fixtures/schema.js
+++ b/lib/utils/generateManifest/fixtures/schema.js
@@ -185,7 +185,7 @@ const azionConfigSchema = {
                   additionalProperties:
                     "No additional properties are allowed in the 'setOrigin' object.",
                   required:
-                    "The 'type' field is required in the 'setOrigin' object.",
+                    "The 'name or type' field is required in the 'setOrigin' object.",
                 },
               },
               rewrite: {

--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -36,6 +36,7 @@ function processManifestConfig(config) {
   validateConfig(config);
 
   const payloadCDN = {
+    origin: [],
     rules: [],
     cache: [],
   };
@@ -51,6 +52,33 @@ function processManifestConfig(config) {
     }
     throw new Error(`Expression is not purely mathematical: ${expression}`);
   };
+
+  // Convert origin settings
+  if (config && config.origin && config.origin.length > 0) {
+    config.origin.forEach((origin) => {
+      if (origin.type !== 'object_storage' && origin.type !== 'single_origin') {
+        throw new Error(
+          `Rule setOrigin originType '${origin.type}' is not supported`,
+        );
+      }
+      const originSetting = {
+        name: origin.name,
+        origin_type: origin.type,
+      };
+
+      if (origin.type === 'object_storage') {
+        originSetting.bucket = origin.bucket;
+        originSetting.prefix = origin.prefix;
+      }
+      if (origin.type === 'single_origin') {
+        originSetting.addresses = origin.addresses?.map((address) => {
+          return { address };
+        });
+        originSetting.host_header = origin.hostHeader;
+      }
+      payloadCDN.origin.push(originSetting);
+    });
+  }
 
   // Convert cache settings
   if (config && config.cache && config.cache.length > 0) {
@@ -154,13 +182,25 @@ function processManifestConfig(config) {
     }
 
     if (rule.setOrigin) {
+      const origin = payloadCDN.origin.find(
+        (o) =>
+          o.name === rule.setOrigin.name &&
+          o.origin_type === rule.setOrigin.type,
+      );
+
+      if (!origin) {
+        throw new Error(
+          `Rule setOrigin name '${rule.setOrigin.name}' not found in the origin settings`,
+        );
+      } else if (origin.origin_type !== rule.setOrigin.type) {
+        throw new Error(
+          `Rule setOrigin originType '${rule.setOrigin.type}' does not match the origin settings`,
+        );
+      }
+
       const originBehavior = {
-        rule: 'set_origin',
-        target: {
-          origin_type: rule.setOrigin.type,
-          bucket: rule.setOrigin.bucket || '',
-          prefix: rule.setOrigin.prefix || '/',
-        },
+        name: 'set_origin',
+        target: origin.name,
       };
 
       cdnRule.behaviors.push(originBehavior);
@@ -219,7 +259,7 @@ async function generateManifest(configModule) {
   const manifestPath = join(edgeDirPath, 'manifest.json');
 
   //  preset configuration (existingManifest) have priority over user azion.config.js
-  let existingManifest = { rules: [], cache: [] };
+  let existingManifest = { origin: [], rules: [], cache: [] };
 
   if (!existsSync(edgeDirPath)) {
     mkdirSync(edgeDirPath);
@@ -231,6 +271,14 @@ async function generateManifest(configModule) {
   }
 
   const newManifestConfig = processManifestConfig(configModule);
+  const originMap = {};
+  existingManifest?.origin?.forEach((setting) => {
+    originMap[setting.name] = setting;
+  });
+  newManifestConfig?.origin?.forEach((setting) => {
+    originMap[setting.name] = setting;
+  });
+
   const cacheMap = {};
   existingManifest?.cache?.forEach((setting) => {
     cacheMap[setting.name] = setting;
@@ -248,6 +296,7 @@ async function generateManifest(configModule) {
   });
 
   const mergedConfig = {
+    origin: Object.values(originMap),
     cache: Object.values(cacheMap),
     rules: Object.values(rulesMap),
   };

--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -106,13 +106,17 @@ function processManifestConfig(config) {
   // Convert rules
   config?.rules?.request?.forEach((rule) => {
     const cdnRule = {
-      criteria: {
-        // eslint-disable-next-line no-template-curly-in-string
-        variable: '${uri}',
-        operator: 'matches',
-        conditional: 'if',
-        input_value: rule.match,
-      },
+      criteria: [
+        [
+          {
+            // eslint-disable-next-line no-template-curly-in-string
+            variable: '${uri}',
+            operator: 'matches',
+            conditional: 'if',
+            input_value: rule.match,
+          },
+        ],
+      ],
       behaviors: rule.behaviors ? [...rule.behaviors] : [],
     };
 
@@ -289,10 +293,10 @@ async function generateManifest(configModule) {
 
   const rulesMap = {};
   existingManifest?.rules?.forEach((rule) => {
-    rulesMap[rule.criteria.input_value] = rule;
+    rulesMap[rule.criteria[0][0].input_value] = rule;
   });
   newManifestConfig?.rules?.forEach((rule) => {
-    rulesMap[rule.criteria.input_value] = rule;
+    rulesMap[rule.criteria[0][0].input_value] = rule;
   });
 
   const mergedConfig = {

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -1,3 +1,4 @@
+import { describe, expect } from '@jest/globals';
 import { processManifestConfig } from './generateManifest.utils.js';
 
 describe('processManifestConfig', () => {
@@ -114,11 +115,20 @@ describe('processManifestConfig', () => {
 
   it('should correctly convert request rules', () => {
     const azionConfig = {
+      origin: [
+        {
+          name: 'my origin storage',
+          type: 'object_storage',
+          bucket: 'mybucket',
+          prefix: 'myfolder',
+        },
+      ],
       rules: {
         request: [
           {
             match: '/api',
             setOrigin: {
+              name: 'my origin storage',
               type: 'object_storage',
             },
           },
@@ -139,12 +149,8 @@ describe('processManifestConfig', () => {
           ]),
           behaviors: expect.arrayContaining([
             expect.objectContaining({
-              rule: 'set_origin',
-              target: {
-                origin_type: 'object_storage',
-                bucket: '',
-                prefix: '/',
-              },
+              name: 'set_origin',
+              target: 'my origin storage',
             }),
           ]),
         }),
@@ -250,31 +256,32 @@ describe('processManifestConfig', () => {
   });
   it('should correctly process the setOrigin rule with all optional fields provided', () => {
     const azionConfigWithAllFields = {
+      origin: [
+        {
+          name: 'my origin storage',
+          type: 'object_storage',
+          bucket: 'mybucket',
+          prefix: 'myfolder',
+        },
+      ],
       rules: {
         request: [
           {
             match: '/_next',
             setOrigin: {
-              name: 'optionalName',
+              name: 'my origin storage',
               type: 'object_storage',
-              bucket: 'optionalBucket',
-              prefix: 'customPrefix',
             },
           },
         ],
       },
     };
-
     const resultWithAllFields = processManifestConfig(azionConfigWithAllFields);
     expect(resultWithAllFields.rules[0].behaviors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          rule: 'set_origin',
-          target: {
-            origin_type: 'object_storage',
-            bucket: 'optionalBucket',
-            prefix: 'customPrefix',
-          },
+          name: 'set_origin',
+          target: 'my origin storage',
         }),
       ]),
     );
@@ -288,7 +295,6 @@ describe('processManifestConfig', () => {
             match: '/_next_no_type',
             setOrigin: {
               name: 'nameWithoutType',
-              bucket: 'bucketWithoutType',
               // type is missing
             },
           },
@@ -297,74 +303,10 @@ describe('processManifestConfig', () => {
     };
 
     expect(() => processManifestConfig(azionConfigWithTypeMissing)).toThrow(
-      "The 'type' field is required in the 'setOrigin' object.",
+      "The 'name or type' field is required in the 'setOrigin' object.",
     );
   });
 
-  it('should correctly process the setOrigin rule with default prefix when not specified', () => {
-    const azionConfigWithDefaultPrefix = {
-      rules: {
-        request: [
-          {
-            match: '/_next_default_prefix',
-            setOrigin: {
-              type: 'object_storage',
-              bucket: 'test',
-              // prefix is missing, should default to '/'
-            },
-          },
-        ],
-      },
-    };
-
-    const resultWithDefaultPrefix = processManifestConfig(
-      azionConfigWithDefaultPrefix,
-    );
-    expect(resultWithDefaultPrefix.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          rule: 'set_origin',
-          target: {
-            origin_type: 'object_storage',
-            bucket: 'test',
-            prefix: '/',
-          },
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly process the setOrigin rule when bucket and name are not provided', () => {
-    const azionConfigWithNullBucketName = {
-      rules: {
-        request: [
-          {
-            match: '/_next_null_bucket_name',
-            setOrigin: {
-              type: 'object_storage',
-              // bucket and name are null or not provided
-            },
-          },
-        ],
-      },
-    };
-
-    const resultWithNullBucketName = processManifestConfig(
-      azionConfigWithNullBucketName,
-    );
-    expect(resultWithNullBucketName.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          rule: 'set_origin',
-          target: {
-            origin_type: 'object_storage',
-            bucket: '',
-            prefix: '/',
-          },
-        }),
-      ]),
-    );
-  });
   it('should throw an error for an undefined property', () => {
     const azionConfigWithUndefinedProperty = {
       cache: [
@@ -571,5 +513,197 @@ describe('processManifestConfig', () => {
         }),
       ]),
     );
+  });
+
+  describe('Origin - processManifestConfig', () => {
+    it('should process the manifest config when the origin name and type are the same as the rules setOrigin name and type', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my origin storage',
+            type: 'object_storage',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
+          },
+        ],
+        rules: {
+          request: [
+            {
+              match: '/api',
+              setOrigin: {
+                name: 'my origin storage',
+                type: 'object_storage',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => processManifestConfig(azionConfig)).not.toThrow();
+      const result = processManifestConfig(azionConfig);
+      expect(result.origin).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'my origin storage',
+            origin_type: 'object_storage',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
+          }),
+        ]),
+      );
+    });
+
+    it('should throw an error when the origin name is different from the rules setOrigin name', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my origin storage',
+            type: 'object_storage',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
+          },
+        ],
+        rules: {
+          request: [
+            {
+              match: '/api',
+              setOrigin: {
+                name: 'another origin storage',
+                type: 'object_storage',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => processManifestConfig(azionConfig)).toThrow(
+        "Rule setOrigin name 'another origin storage' not found in the origin settings",
+      );
+    });
+
+    it('should throw an error when the origin type is different from the rules setOrigin type', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my origin storage',
+            type: 'object_storage',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
+          },
+        ],
+        rules: {
+          request: [
+            {
+              match: '/api',
+              setOrigin: {
+                name: 'my origin storage',
+                type: 'another_type',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => processManifestConfig(azionConfig)).toThrow(
+        "Rule setOrigin name 'my origin storage' not found in the origin settings",
+      );
+    });
+
+    it('should throw an error when the origin settings are not defined', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              match: '/api',
+              setOrigin: {
+                name: 'my origin storage',
+                type: 'object_storage',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => processManifestConfig(azionConfig)).toThrow(
+        "Rule setOrigin name 'my origin storage' not found in the origin settings",
+      );
+    });
+
+    // should throw an error when the origin type is incorret
+    it('should throw an error when the origin type is incorrect', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my origin storage',
+            type: 'name_incorrect',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
+          },
+        ],
+        rules: {
+          request: [
+            {
+              match: '/api',
+              setOrigin: {
+                name: 'my origin storage',
+                type: 'another_type',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => processManifestConfig(azionConfig)).toThrow(
+        "Rule setOrigin originType 'name_incorrect' is not supported",
+      );
+    });
+
+    it('should correctly process the manifest config when the origin is single_origin', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my single origin',
+            type: 'single_origin',
+            hostHeader: 'www.example.com',
+            addresses: ['test.com'],
+          },
+        ],
+        rules: {
+          request: [
+            {
+              match: '/api',
+              setOrigin: {
+                name: 'my single origin',
+                type: 'single_origin',
+              },
+            },
+          ],
+        },
+      };
+      expect(() => processManifestConfig(azionConfig)).not.toThrow();
+      const result = processManifestConfig(azionConfig);
+      expect(result.origin).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'my single origin',
+            origin_type: 'single_origin',
+            addresses: [
+              {
+                address: 'test.com',
+              },
+            ],
+            host_header: 'www.example.com',
+          }),
+        ]),
+      );
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'set_origin',
+            target: 'my single origin',
+          }),
+        ]),
+      );
+    });
   });
 });

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -26,6 +26,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/test',
             cache: {
               name: 'directCache',
@@ -51,6 +52,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/test',
             rewrite: {
               match: '^(./)([^/])$',
@@ -65,7 +67,7 @@ describe('processManifestConfig', () => {
     expect(result.rules[0].behaviors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          rule: 'rewrite_request',
+          name: 'rewrite_request',
           target: expect.stringContaining('/%{other[0]}/%{other[1]}'), // Updated from 'params' to 'target'
         }),
       ]),
@@ -100,6 +102,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/no-cache',
             runFunction: {
               path: '.edge/worker.js',
@@ -126,6 +129,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/api',
             setOrigin: {
               name: 'my origin storage',
@@ -202,6 +206,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/',
             forwardCookies: true,
           },
@@ -214,7 +219,7 @@ describe('processManifestConfig', () => {
     expect(result.rules[0].behaviors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          rule: 'forward_cookies',
+          name: 'forward_cookies',
           target: null, // Updated from 'params' to 'target'
         }),
       ]),
@@ -226,10 +231,12 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/no-forward',
             forwardCookies: false,
           },
           {
+            name: 'testRule',
             match: '/default-forward',
             // forwardCookies not specified
           },
@@ -242,14 +249,14 @@ describe('processManifestConfig', () => {
     expect(result.rules[0].behaviors).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          rule: 'forward_cookies',
+          name: 'forward_cookies',
         }),
       ]),
     );
     expect(result.rules[1].behaviors).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          rule: 'forward_cookies',
+          name: 'forward_cookies',
         }),
       ]),
     );
@@ -267,6 +274,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/_next',
             setOrigin: {
               name: 'my origin storage',
@@ -292,6 +300,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/_next_no_type',
             setOrigin: {
               name: 'nameWithoutType',
@@ -322,37 +331,12 @@ describe('processManifestConfig', () => {
     ).toThrow('No additional properties are allowed in cache item objects.');
   });
 
-  it('should correctly process the runFunction behavior with a valid path and optional name', () => {
-    const azionConfigWithRunFunction = {
-      rules: {
-        request: [
-          {
-            match: '/run-function-test',
-            runFunction: {
-              path: '.edge/worker.js',
-              name: 'optionalFunctionName',
-            },
-          },
-        ],
-      },
-    };
-
-    const expectedBehavior = {
-      name: 'optionalFunctionName',
-      target: '.edge/worker.js',
-    };
-
-    const result = processManifestConfig(azionConfigWithRunFunction);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([expect.objectContaining(expectedBehavior)]),
-    );
-  });
-
   it('should correctly process the runFunction behavior with only the required path', () => {
     const azionConfigWithRunFunctionOnlyPath = {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/run-function-test-path-only',
             runFunction: {
               path: '.edge/worker.js',
@@ -380,6 +364,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/path',
             deliver: true,
           },
@@ -391,7 +376,7 @@ describe('processManifestConfig', () => {
     expect(result.rules[0].behaviors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          rule: 'deliver',
+          name: 'deliver',
         }),
       ]),
     );
@@ -401,6 +386,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/path',
             deliver: 'true', // Incorretamente definido como string
           },
@@ -418,6 +404,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/',
             setCookie: true, // Incorretamente definido como boolean
           },
@@ -435,6 +422,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/',
             setHeaders: { key: 'value' }, // Incorretamente definido como objeto
           },
@@ -452,6 +440,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/path',
             deliver: true,
           },
@@ -463,7 +452,7 @@ describe('processManifestConfig', () => {
     expect(result.rules[0].behaviors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          rule: 'deliver',
+          name: 'deliver',
         }),
       ]),
     );
@@ -474,6 +463,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/',
             setCookie: 'sessionId=abc123',
           },
@@ -485,7 +475,7 @@ describe('processManifestConfig', () => {
     expect(result.rules[0].behaviors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          rule: 'add_request_cookie',
+          name: 'add_request_cookie',
           target: 'sessionId=abc123',
         }),
       ]),
@@ -497,6 +487,7 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
+            name: 'testRule',
             match: '/',
             setHeaders: 'Authorization: Bearer abc123',
           },
@@ -508,7 +499,7 @@ describe('processManifestConfig', () => {
     expect(result.rules[0].behaviors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          rule: 'add_request_header',
+          name: 'add_request_header',
           target: 'Authorization: Bearer abc123',
         }),
       ]),
@@ -529,6 +520,7 @@ describe('processManifestConfig', () => {
         rules: {
           request: [
             {
+              name: 'testRule',
               match: '/api',
               setOrigin: {
                 name: 'my origin storage',
@@ -566,6 +558,7 @@ describe('processManifestConfig', () => {
         rules: {
           request: [
             {
+              name: 'testRule',
               match: '/api',
               setOrigin: {
                 name: 'another origin storage',
@@ -594,6 +587,7 @@ describe('processManifestConfig', () => {
         rules: {
           request: [
             {
+              name: 'testRule',
               match: '/api',
               setOrigin: {
                 name: 'my origin storage',
@@ -614,6 +608,7 @@ describe('processManifestConfig', () => {
         rules: {
           request: [
             {
+              name: 'testRule',
               match: '/api',
               setOrigin: {
                 name: 'my origin storage',
@@ -643,6 +638,7 @@ describe('processManifestConfig', () => {
         rules: {
           request: [
             {
+              name: 'testRule',
               match: '/api',
               setOrigin: {
                 name: 'my origin storage',
@@ -671,6 +667,7 @@ describe('processManifestConfig', () => {
         rules: {
           request: [
             {
+              name: 'testRule',
               match: '/api',
               setOrigin: {
                 name: 'my single origin',


### PR DESCRIPTION
Adding the origin configuration to the manifest.

Example:

`azion.config.js`

```js

export default {
  origin: [
    {
      name: "my origin storage",
      type: "object_storage",
      bucket: "mybucket",
      prefix: "myfolder",
    },
  ],
  rules: {
    request: [
      {
        match: "/^/_statics/;", // start with /_statics
        setOrigin: {
          name: "my origin storage",
          type: "object_storage",
        },
      }
    ],
  },
};

```

The manifest generated in: `./.edge/manifest.json`

```json
{
  "origin": [
    {
      "name": "my origin storage",
      "origin_type": "object_storage",
      "bucket": "mybucket",
      "prefix": "myfolder"
    }
  ],
  "cache": [],
  "rules": [
   ...
    {
      "criteria": [
        [
          {
            "variable": "${uri}",
            "operator": "matches",
            "conditional": "if",
            "input_value": "/^/_statics/;"
          }
        ]
      ],
      "behaviors": [
        {
          "name": "set_origin",
          "target": "my origin storage"
        }
      ]
    }
  ]
}
```