### PR TITLE
chore: adjusts manifest rules names

### DIFF
--- a/lib/presets/custom/angular/deliver/prebuild.js
+++ b/lib/presets/custom/angular/deliver/prebuild.js
@@ -8,6 +8,7 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         setOrigin: {
           type: 'object_storage',

--- a/lib/presets/custom/astro/deliver/prebuild.js
+++ b/lib/presets/custom/astro/deliver/prebuild.js
@@ -12,6 +12,7 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         setOrigin: {
           type: 'object_storage',

--- a/lib/presets/custom/eleventy/deliver/prebuild.js
+++ b/lib/presets/custom/eleventy/deliver/prebuild.js
@@ -5,12 +5,14 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         setOrigin: {
           type: 'object_storage',
         },
       },
       {
+        name: 'Index_Rewrite_1',
         match: '.*/$',
         // eslint-disable-next-line no-template-curly-in-string
         rewrite: {
@@ -18,6 +20,7 @@ const manifest = {
         },
       },
       {
+        name: 'Index_Rewrite_2',
         match: '^(?!.*/$)(?![sS]*.[a-zA-Z0-9]+$).*',
         // eslint-disable-next-line no-template-curly-in-string
         rewrite: {

--- a/lib/presets/custom/emscripten/compute/prebuild.js
+++ b/lib/presets/custom/emscripten/compute/prebuild.js
@@ -5,6 +5,7 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         runFunction: {
           path: '.edge/worker.js',

--- a/lib/presets/custom/gatsby/deliver/prebuild.js
+++ b/lib/presets/custom/gatsby/deliver/prebuild.js
@@ -12,6 +12,7 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         setOrigin: {
           type: 'object_storage',

--- a/lib/presets/custom/hexo/deliver/prebuild.js
+++ b/lib/presets/custom/hexo/deliver/prebuild.js
@@ -12,12 +12,14 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         setOrigin: {
           type: 'object_storage',
         },
       },
       {
+        name: 'Index_Rewrite_1',
         match: '.*/$',
         // eslint-disable-next-line no-template-curly-in-string
         rewrite: {
@@ -25,6 +27,7 @@ const manifest = {
         },
       },
       {
+        name: 'Index_Rewrite_2',
         match: '^(?!.*/$)(?![sS]*.[a-zA-Z0-9]+$).*',
         // eslint-disable-next-line no-template-curly-in-string
         rewrite: {

--- a/lib/presets/custom/hugo/deliver/prebuild.js
+++ b/lib/presets/custom/hugo/deliver/prebuild.js
@@ -12,12 +12,14 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         setOrigin: {
           type: 'object_storage',
         },
       },
       {
+        name: 'Index_Rewrite_1',
         match: '.*/$',
         // eslint-disable-next-line no-template-curly-in-string
         rewrite: {
@@ -25,6 +27,7 @@ const manifest = {
         },
       },
       {
+        name: 'Index_Rewrite_2',
         match: '^(?!.*/$)(?![sS]*.[a-zA-Z0-9]+$).*',
         // eslint-disable-next-line no-template-curly-in-string
         rewrite: {

--- a/lib/presets/custom/next/compute/prebuild.js
+++ b/lib/presets/custom/next/compute/prebuild.js
@@ -15,6 +15,7 @@ const edgeManifest = {
   rules: {
     request: [
       {
+        name: 'Assets_Rule_1',
         match: '/^/_next/static/;', // starts with '/_next/static/'
         setOrigin: {
           type: 'object_storage',
@@ -22,6 +23,7 @@ const edgeManifest = {
         deliver: true,
       },
       {
+        name: 'Assets_Rule_2',
         match: '.(css|js|ttf|woff|woff2|pdf|svg|jpg|jpeg|gif|bmp|png|ico|mp4)$',
         setOrigin: {
           type: 'object_storage',
@@ -29,6 +31,7 @@ const edgeManifest = {
         deliver: true,
       },
       {
+        name: 'Compute_Rule',
         match: '^/',
         runFunction: {
           path: '.edge/worker.js',

--- a/lib/presets/custom/next/deliver/prebuild.js
+++ b/lib/presets/custom/next/deliver/prebuild.js
@@ -18,12 +18,14 @@ const cdnManifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         setOrigin: {
           type: 'object_storage',
         },
       },
       {
+        name: 'Index_Rewrite_1',
         match: '.*/$',
         // eslint-disable-next-line no-template-curly-in-string
         rewrite: {
@@ -31,6 +33,7 @@ const cdnManifest = {
         },
       },
       {
+        name: 'Index_Rewrite_2',
         match: '^(?!.*/$)(?![sS]*.[a-zA-Z0-9]+$).*',
         // eslint-disable-next-line no-template-curly-in-string
         rewrite: {

--- a/lib/presets/custom/react/deliver/prebuild.js
+++ b/lib/presets/custom/react/deliver/prebuild.js
@@ -6,6 +6,7 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         setOrigin: {
           type: 'object_storage',

--- a/lib/presets/custom/rustwasm/compute/prebuild.js
+++ b/lib/presets/custom/rustwasm/compute/prebuild.js
@@ -5,6 +5,7 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         runFunction: {
           path: '.edge/worker.js',

--- a/lib/presets/custom/vue/deliver/prebuild.js
+++ b/lib/presets/custom/vue/deliver/prebuild.js
@@ -14,6 +14,7 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         setOrigin: {
           type: 'object_storage',

--- a/lib/presets/default/html/deliver/prebuild.js
+++ b/lib/presets/default/html/deliver/prebuild.js
@@ -4,6 +4,7 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         setOrigin: {
           type: 'object_storage',

--- a/lib/presets/default/javascript/compute/prebuild.js
+++ b/lib/presets/default/javascript/compute/prebuild.js
@@ -4,6 +4,7 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         runFunction: {
           path: '.edge/worker.js',

--- a/lib/presets/default/typescript/compute/prebuild.js
+++ b/lib/presets/default/typescript/compute/prebuild.js
@@ -4,6 +4,7 @@ const manifest = {
   rules: {
     request: [
       {
+        name: 'Main_Rule',
         match: '^\\/',
         runFunction: {
           path: '.edge/worker.js',

--- a/lib/utils/generateManifest/fixtures/schema.js
+++ b/lib/utils/generateManifest/fixtures/schema.js
@@ -252,12 +252,13 @@ const azionConfigSchema = {
                   "The 'cache' field must be either a string or an object with specified properties.",
               },
             },
-            required: ['match'],
+            required: ['name', 'match'],
             additionalProperties: false,
             errorMessage: {
               additionalProperties:
                 'No additional properties are allowed in request items.',
-              required: "The 'match' field is required in each request item.",
+              required:
+                "The 'name and match' fields are required in each request item.",
             },
           },
         },

--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -78,6 +78,7 @@ function processManifestConfig(config) {
   // Convert rules
   config?.rules?.request?.forEach((rule) => {
     const cdnRule = {
+      name: rule.name,
       criteria: {
         // eslint-disable-next-line no-template-curly-in-string
         variable: '${uri}',

--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -101,7 +101,7 @@ function processManifestConfig(config) {
 
       if (rule.rewrite.match) {
         cdnRule.behaviors.push({
-          rule: 'capture_match_groups',
+          name: 'capture_match_groups',
           target: {
             captured_array: paramName || 'captured',
             // eslint-disable-next-line no-template-curly-in-string
@@ -117,7 +117,7 @@ function processManifestConfig(config) {
         .replace(/\$\{([^}]+)\}/g, (match, p1) => `%{${p1}}`); // Replace ${other[index]} with %{other[index]}
 
       cdnRule.behaviors.push({
-        rule: 'rewrite_request',
+        name: 'rewrite_request',
         target: pathTransformation,
       });
     }
@@ -125,7 +125,7 @@ function processManifestConfig(config) {
     // Cache handling within rules
     if (typeof rule.cache === 'string') {
       cdnRule.behaviors.push({
-        rule: 'set_cache_policy',
+        name: 'set_cache_policy',
         target: rule.cache,
       });
     } else if (typeof rule.cache === 'object') {
@@ -137,7 +137,7 @@ function processManifestConfig(config) {
       payloadCDN.cache.push(cacheSetting);
       // Adds the set_cache_policy behavior with the generated cache name
       cdnRule.behaviors.push({
-        rule: 'set_cache_policy',
+        name: 'set_cache_policy',
         target: rule.cache?.name,
       });
       // Updates the rule to use the generated cache name
@@ -148,7 +148,7 @@ function processManifestConfig(config) {
     if (Object.prototype.hasOwnProperty.call(rule, 'forwardCookies')) {
       if (rule.forwardCookies) {
         cdnRule.behaviors.push({
-          rule: 'forward_cookies',
+          name: 'forward_cookies',
           target: null,
         });
       }
@@ -156,7 +156,7 @@ function processManifestConfig(config) {
 
     if (rule.setOrigin) {
       const originBehavior = {
-        rule: 'set_origin',
+        name: 'set_origin',
         target: {
           origin_type: rule.setOrigin.type,
           bucket: rule.setOrigin.bucket || '',
@@ -169,26 +169,22 @@ function processManifestConfig(config) {
 
     if (rule.runFunction) {
       const runFunctionBehavior = {
-        rule: 'run_function',
+        name: 'run_function',
         target: rule.runFunction.path,
       };
-
-      if (rule.runFunction.name) {
-        runFunctionBehavior.name = rule.runFunction.name;
-      }
 
       cdnRule.behaviors.push(runFunctionBehavior);
     }
 
     if (rule.deliver) {
       cdnRule.behaviors.push({
-        rule: 'deliver',
+        name: 'deliver',
       });
     }
 
     if (rule.setCookie) {
       const cookieBehavior = {
-        rule: 'add_request_cookie',
+        name: 'add_request_cookie',
         target: rule.setCookie,
       };
       cdnRule.behaviors.push(cookieBehavior);
@@ -196,7 +192,7 @@ function processManifestConfig(config) {
 
     if (rule.setHeaders) {
       const headersBehavior = {
-        rule: 'add_request_header',
+        name: 'add_request_header',
         target: rule.setHeaders,
       };
       cdnRule.behaviors.push(headersBehavior);


### PR DESCRIPTION
In this PR:
- Set default name to presets rules;
- Make name required in azion config rules;
- Change behavior attribute 'rule' to 'name' in generated manifest (requested by Azion CLI);