### PR TITLE
fix: generating a temporary file for creating the manifest

### DIFF
--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -347,7 +347,7 @@ class Dispatcher {
     const buildConfigPath = join(process.cwd(), 'azion.config.js');
     if (existsSync(buildConfigPath)) {
       const vulcanCustomConfigModule = (await import(buildConfigPath)).default;
-      await generateManifest(vulcanCustomConfigModule);
+      await generateManifest(vulcanCustomConfigModule, true);
       feedback.build.success('Manifest generated successfully.');
     }
   }
@@ -555,6 +555,7 @@ class Dispatcher {
       }
 
       await Dispatcher.generateCustomManifest();
+
       feedback.build.success(Messages.build.success.vulcan_build_succeeded);
     } catch (error) {
       if (existsSync(buildEntryTemp)) {

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -342,14 +342,15 @@ class Dispatcher {
     writeFileSync(filePath, content);
   }
 
-  static async generateCustomManifest() {
+  static async generateFinalManifest() {
     feedback.build.info('Checking Azion CDN configuration file...');
     const buildConfigPath = join(process.cwd(), 'azion.config.js');
+    let vulcanCustomConfigModule = {};
     if (existsSync(buildConfigPath)) {
-      const vulcanCustomConfigModule = (await import(buildConfigPath)).default;
-      await generateManifest(vulcanCustomConfigModule, true);
-      feedback.build.success('Manifest generated successfully.');
+      vulcanCustomConfigModule = (await import(buildConfigPath)).default;
     }
+    await generateManifest(vulcanCustomConfigModule, true);
+    feedback.build.success('Manifest generated successfully.');
   }
 
   /**
@@ -554,7 +555,7 @@ class Dispatcher {
         await postbuild(buildConfig);
       }
 
-      await Dispatcher.generateCustomManifest();
+      await Dispatcher.generateFinalManifest();
 
       feedback.build.success(Messages.build.success.vulcan_build_succeeded);
     } catch (error) {

--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -1,10 +1,13 @@
-import { existsSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
+import { existsSync, writeFileSync, readFileSync, mkdirSync, rm } from 'fs';
 import { join } from 'path';
 import Ajv from 'ajv';
 import ajvErrors from 'ajv-errors';
 import addKeywords from 'ajv-keywords';
+import os from 'node:os';
+import lodash from 'lodash';
 
 import azionConfigSchema from './fixtures/schema.js';
+import debug from '../debug/debug.utils.js';
 
 /**
  * Validates the provided configuration against a JSON Schema.
@@ -249,18 +252,63 @@ function processManifestConfig(config) {
 }
 
 /**
+ * Removes the temporary folder used to store the manifest file.
+ * This function is typically called after the manifest is generated and copied to the edge directory.
+ */
+function removeTmpFolder() {
+  const manifestPath = globalThis.vulcan.tmpManifestFile;
+  if (manifestPath) {
+    const dirName = manifestPath.substring(0, manifestPath.lastIndexOf('/'));
+    rm(dirName, { recursive: true }, (err) => {
+      if (err) {
+        debug.error(err);
+      }
+    });
+  }
+  globalThis.vulcan.tmpManifestFile = null;
+}
+
+/**
+ * Create the final manifest file to the edge directory.
+ */
+async function generateFinalManifest() {
+  const manifestPath = globalThis.vulcan.tmpManifestFile;
+  const finalManifestPath = join(process.cwd(), '.edge', 'manifest.json');
+  if (existsSync(manifestPath)) {
+    writeFileSync(finalManifestPath, readFileSync(manifestPath));
+    removeTmpFolder();
+  } else {
+    throw new Error('Manifest file not found');
+  }
+}
+
+/**
  * Generates or updates the CDN manifest based on a custom configuration module.
  * If an existing manifest is found, it merges the configurations, prioritizing the custom module.
  * This function is typically called during the prebuild stage to prepare the CDN configuration.
  * @param {object} configModule - The custom configuration module provided by the user.
+ * @param {boolean} shouldGenerateFinalManifest - A flag indicating whether the final manifest should be generated after the temporary manifest is created.
  * @async
  */
-async function generateManifest(configModule) {
+async function generateManifest(
+  configModule,
+  shouldGenerateFinalManifest = false,
+) {
   const edgeDirPath = join(process.cwd(), '.edge');
-  const manifestPath = join(edgeDirPath, 'manifest.json');
+  const tmpDirPath = join(os.tmpdir(), 'vulcan');
+
+  if (!existsSync(tmpDirPath)) {
+    mkdirSync(tmpDirPath);
+  }
+
+  let manifestPath = globalThis.vulcan.tmpManifestFile;
+  if (!manifestPath) {
+    manifestPath = join(tmpDirPath, `manifest-${new Date().getTime()}.json`);
+    globalThis.vulcan.tmpManifestFile = manifestPath;
+  }
 
   //  preset configuration (existingManifest) have priority over user azion.config.js
-  let existingManifest = { origin: [], rules: [], cache: [] };
+  let existingManifest = {};
 
   if (!existsSync(edgeDirPath)) {
     mkdirSync(edgeDirPath);
@@ -272,37 +320,31 @@ async function generateManifest(configModule) {
   }
 
   const newManifestConfig = processManifestConfig(configModule);
-  const originMap = {};
-  existingManifest?.origin?.forEach((setting) => {
-    originMap[setting.name] = setting;
-  });
-  newManifestConfig?.origin?.forEach((setting) => {
-    originMap[setting.name] = setting;
-  });
 
-  const cacheMap = {};
-  existingManifest?.cache?.forEach((setting) => {
-    cacheMap[setting.name] = setting;
-  });
-  newManifestConfig?.cache?.forEach((setting) => {
-    cacheMap[setting.name] = setting;
-  });
+  // eslint-disable-next-line
+  function customizer(objValue, srcValue) {
+    if (Array.isArray(objValue)) {
+      return objValue.concat(
+        srcValue.filter(
+          (srcItem) =>
+            !objValue.some((objItem) => objItem?.name === srcItem?.name),
+        ),
+      );
+    }
+  }
 
-  const rulesMap = {};
-  existingManifest?.rules?.forEach((rule) => {
-    rulesMap[rule.criteria[0][0].input_value] = rule;
-  });
-  newManifestConfig?.rules?.forEach((rule) => {
-    rulesMap[rule.criteria[0][0].input_value] = rule;
-  });
+  // Merge the new configuration with the existing manifest with priority to the existing manifest
+  const mergeManifest = lodash.mergeWith(
+    existingManifest,
+    newManifestConfig,
+    customizer,
+  );
 
-  const mergedConfig = {
-    origin: Object.values(originMap),
-    cache: Object.values(cacheMap),
-    rules: Object.values(rulesMap),
-  };
+  writeFileSync(manifestPath, JSON.stringify(mergeManifest, null, 2));
 
-  writeFileSync(manifestPath, JSON.stringify(mergedConfig, null, 2));
+  if (shouldGenerateFinalManifest) {
+    await generateFinalManifest();
+  }
 }
 
 export { processManifestConfig, generateManifest };

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -1,109 +1,20 @@
 import { describe, expect } from '@jest/globals';
-import { processManifestConfig } from './generateManifest.utils.js';
+import { readFileSync } from 'node:fs';
+import mockFs from 'mock-fs';
+import {
+  generateManifest,
+  processManifestConfig,
+} from './generateManifest.utils.js';
 
-describe('processManifestConfig', () => {
-  it('should throw an error for invalid mathematical expressions', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          browser: { maxAgeSeconds: '2 * 3' },
-          edge: { maxAgeSeconds: 'invalidExpression' },
-        },
-      ],
-      rules: {
-        request: [],
-      },
-    };
-
-    expect(() => processManifestConfig(azionConfig)).toThrow(
-      "The 'maxAgeSeconds' field must be a number or a valid mathematical expression.",
-    );
-  });
-
-  it('should process a cache object directly in the rule', () => {
-    const azionConfig = {
+describe('Utils - generateManifest', () => {
+  it('should correctly merge config when generateManifest is called multiple times', async () => {
+    globalThis.vulcan = {};
+    const presetConfig = {
       rules: {
         request: [
           {
-            name: 'testRule',
-            match: '/test',
-            cache: {
-              name: 'directCache',
-              browser_cache_settings_maximum_ttl: 300,
-              cdn_cache_settings_maximum_ttl: 600,
-            },
-          },
-        ],
-      },
-    };
-
-    const result = processManifestConfig(azionConfig);
-    expect(result).toHaveProperty('cache');
-    expect(result.cache).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ name: 'directCache' }),
-      ]),
-    );
-  });
-
-  it('should handle rewrites with dynamic parameter names correctly', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/test',
-            rewrite: {
-              match: '^(./)([^/])$',
-              set: (other) => `/${other[0]}/${other[1]}`,
-            },
-          },
-        ],
-      },
-    };
-
-    const result = processManifestConfig(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'rewrite_request',
-          target: expect.stringContaining('/%{other[0]}/%{other[1]}'), // Updated from 'params' to 'target'
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly calculate numerical values', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'calcCache',
-          browser: { maxAgeSeconds: '2 * 3' },
-          edge: { maxAgeSeconds: '4 + 1' },
-        },
-      ],
-      rules: {
-        request: [],
-      },
-    };
-
-    const result = processManifestConfig(azionConfig);
-    expect(result.cache[0]).toEqual(
-      expect.objectContaining({
-        browser_cache_settings_maximum_ttl: 6,
-        cdn_cache_settings_maximum_ttl: 5,
-      }),
-    );
-  });
-
-  it('should correctly handle the absence of cache settings', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/no-cache',
+            name: 'Main_Rule',
+            match: '^\\/',
             runFunction: {
               path: '.edge/worker.js',
             },
@@ -111,12 +22,6 @@ describe('processManifestConfig', () => {
         ],
       },
     };
-
-    const result = processManifestConfig(azionConfig);
-    expect(result.cache).toEqual([]);
-  });
-
-  it('should correctly convert request rules', () => {
     const azionConfig = {
       origin: [
         {
@@ -129,8 +34,8 @@ describe('processManifestConfig', () => {
       rules: {
         request: [
           {
-            name: 'testRule',
-            match: '/api',
+            name: 'my-rule-origin',
+            match: '/^/_statics/;',
             setOrigin: {
               name: 'my origin storage',
               type: 'object_storage',
@@ -139,374 +44,579 @@ describe('processManifestConfig', () => {
         ],
       },
     };
+    mockFs({
+      '.edge/manifest.json': '{}',
+    });
+    await generateManifest(presetConfig);
+    await generateManifest(azionConfig, true);
+    const manifest = readFileSync('.edge/manifest.json', 'utf8');
+    mockFs.restore();
+    expect(JSON.parse(manifest)).toEqual(
+      expect.objectContaining({
+        origin: expect.arrayContaining([
+          {
+            name: 'my origin storage',
+            origin_type: 'object_storage',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
+          },
+        ]),
+        rules: expect.arrayContaining([
+          {
+            name: 'my-rule-origin',
+            criteria: [
+              [
+                {
+                  // eslint-disable-next-line no-template-curly-in-string
+                  variable: '${uri}',
+                  operator: 'matches',
+                  conditional: 'if',
+                  input_value: '/^/_statics/;',
+                },
+              ],
+            ],
+            behaviors: [
+              {
+                name: 'set_origin',
+                target: 'my origin storage',
+              },
+            ],
+          },
+          {
+            name: 'Main_Rule',
+            criteria: [
+              [
+                {
+                  // eslint-disable-next-line no-template-curly-in-string
+                  variable: '${uri}',
+                  operator: 'matches',
+                  conditional: 'if',
+                  input_value: '^\\/',
+                },
+              ],
+            ],
+            behaviors: [
+              {
+                name: 'run_function',
+                target: '.edge/worker.js',
+              },
+            ],
+          },
+        ]),
+        cache: [],
+      }),
+    );
+  });
 
-    const result = processManifestConfig(azionConfig);
-    expect(result.rules).toEqual(
-      expect.arrayContaining([
+  describe('processManifestConfig', () => {
+    it('should throw an error for invalid mathematical expressions', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            browser: { maxAgeSeconds: '2 * 3' },
+            edge: { maxAgeSeconds: 'invalidExpression' },
+          },
+        ],
+        rules: {
+          request: [],
+        },
+      };
+
+      expect(() => processManifestConfig(azionConfig)).toThrow(
+        "The 'maxAgeSeconds' field must be a number or a valid mathematical expression.",
+      );
+    });
+
+    it('should process a cache object directly in the rule', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/test',
+              cache: {
+                name: 'directCache',
+                browser_cache_settings_maximum_ttl: 300,
+                cdn_cache_settings_maximum_ttl: 600,
+              },
+            },
+          ],
+        },
+      };
+
+      const result = processManifestConfig(azionConfig);
+      expect(result).toHaveProperty('cache');
+      expect(result.cache).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'directCache' }),
+        ]),
+      );
+    });
+
+    it('should handle rewrites with dynamic parameter names correctly', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/test',
+              rewrite: {
+                match: '^(./)([^/])$',
+                set: (other) => `/${other[0]}/${other[1]}`,
+              },
+            },
+          ],
+        },
+      };
+
+      const result = processManifestConfig(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'rewrite_request',
+            target: expect.stringContaining('/%{other[0]}/%{other[1]}'), // Updated from 'params' to 'target'
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly calculate numerical values', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'calcCache',
+            browser: { maxAgeSeconds: '2 * 3' },
+            edge: { maxAgeSeconds: '4 + 1' },
+          },
+        ],
+        rules: {
+          request: [],
+        },
+      };
+
+      const result = processManifestConfig(azionConfig);
+      expect(result.cache[0]).toEqual(
         expect.objectContaining({
-          criteria: expect.arrayContaining([
-            expect.arrayContaining([
+          browser_cache_settings_maximum_ttl: 6,
+          cdn_cache_settings_maximum_ttl: 5,
+        }),
+      );
+    });
+
+    it('should correctly handle the absence of cache settings', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/no-cache',
+              runFunction: {
+                path: '.edge/worker.js',
+              },
+            },
+          ],
+        },
+      };
+
+      const result = processManifestConfig(azionConfig);
+      expect(result.cache).toEqual([]);
+    });
+
+    it('should correctly convert request rules', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my origin storage',
+            type: 'object_storage',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
+          },
+        ],
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/api',
+              setOrigin: {
+                name: 'my origin storage',
+                type: 'object_storage',
+              },
+            },
+          ],
+        },
+      };
+
+      const result = processManifestConfig(azionConfig);
+      expect(result.rules).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            criteria: expect.arrayContaining([
+              expect.arrayContaining([
+                expect.objectContaining({
+                  input_value: '/api',
+                }),
+              ]),
+            ]),
+            behaviors: expect.arrayContaining([
               expect.objectContaining({
-                input_value: '/api',
+                name: 'set_origin',
+                target: 'my origin storage',
               }),
             ]),
-          ]),
-          behaviors: expect.arrayContaining([
-            expect.objectContaining({
-              name: 'set_origin',
-              target: 'my origin storage',
-            }),
-          ]),
-        }),
-      ]),
-    );
-  });
+          }),
+        ]),
+      );
+    });
 
-  it('should correctly calculate complex mathematical expressions', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'complexMathCache',
-          browser: { maxAgeSeconds: '(2 * 3) + 5' },
-          edge: { maxAgeSeconds: '10 / 2' },
-        },
-      ],
-      rules: {
-        request: [],
-      },
-    };
-
-    const result = processManifestConfig(azionConfig);
-    expect(result.cache[0]).toEqual(
-      expect.objectContaining({
-        browser_cache_settings_maximum_ttl: 11,
-        cdn_cache_settings_maximum_ttl: 5,
-      }),
-    );
-  });
-
-  it('should throw an error when data types do not match the expected', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'typeValidationCache',
-          browser: { maxAgeSeconds: true }, // Invalid boolean type for maxAgeSeconds
-          edge: { maxAgeSeconds: '10' },
-        },
-      ],
-    };
-
-    expect(() => processManifestConfig(azionConfig)).toThrow(
-      "The 'maxAgeSeconds' field must be a number or a valid mathematical expression.",
-    );
-  });
-
-  it('should correctly configure cookie forwarding when forwardCookies is true', () => {
-    const azionConfig = {
-      rules: {
-        request: [
+    it('should correctly calculate complex mathematical expressions', () => {
+      const azionConfig = {
+        cache: [
           {
-            name: 'testRule',
-            match: '/',
-            forwardCookies: true,
+            name: 'complexMathCache',
+            browser: { maxAgeSeconds: '(2 * 3) + 5' },
+            edge: { maxAgeSeconds: '10 / 2' },
           },
         ],
-      },
-    };
+        rules: {
+          request: [],
+        },
+      };
 
-    const result = processManifestConfig(azionConfig);
-    // Checks if the forward_cookies behavior is included and set to true when forwardCookies is true
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
+      const result = processManifestConfig(azionConfig);
+      expect(result.cache[0]).toEqual(
         expect.objectContaining({
-          name: 'forward_cookies',
-          target: null, // Updated from 'params' to 'target'
+          browser_cache_settings_maximum_ttl: 11,
+          cdn_cache_settings_maximum_ttl: 5,
         }),
-      ]),
-    );
-  });
+      );
+    });
 
-  it('should not include forward_cookies behavior when forwardCookies is false or not specified', () => {
-    const azionConfig = {
-      rules: {
-        request: [
+    it('should throw an error when data types do not match the expected', () => {
+      const azionConfig = {
+        cache: [
           {
-            name: 'testRule',
-            match: '/no-forward',
-            forwardCookies: false,
-          },
-          {
-            name: 'testRule',
-            match: '/default-forward',
-            // forwardCookies not specified
+            name: 'typeValidationCache',
+            browser: { maxAgeSeconds: true }, // Invalid boolean type for maxAgeSeconds
+            edge: { maxAgeSeconds: '10' },
           },
         ],
-      },
-    };
+      };
 
-    const result = processManifestConfig(azionConfig);
-    // Checks if the forward_cookies behavior is not included when forwardCookies is false or not specified
-    expect(result.rules[0].behaviors).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'forward_cookies',
-        }),
-      ]),
-    );
-    expect(result.rules[1].behaviors).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'forward_cookies',
-        }),
-      ]),
-    );
-  });
-  it('should correctly process the setOrigin rule with all optional fields provided', () => {
-    const azionConfigWithAllFields = {
-      origin: [
-        {
-          name: 'my origin storage',
-          type: 'object_storage',
-          bucket: 'mybucket',
-          prefix: 'myfolder',
-        },
-      ],
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/_next',
-            setOrigin: {
-              name: 'my origin storage',
-              type: 'object_storage',
+      expect(() => processManifestConfig(azionConfig)).toThrow(
+        "The 'maxAgeSeconds' field must be a number or a valid mathematical expression.",
+      );
+    });
+
+    it('should correctly configure cookie forwarding when forwardCookies is true', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/',
+              forwardCookies: true,
             },
-          },
-        ],
-      },
-    };
-    const resultWithAllFields = processManifestConfig(azionConfigWithAllFields);
-    expect(resultWithAllFields.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'set_origin',
-          target: 'my origin storage',
-        }),
-      ]),
-    );
-  });
-
-  it('should throw an error when "type" is missing in "setOrigin"', () => {
-    const azionConfigWithTypeMissing = {
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/_next_no_type',
-            setOrigin: {
-              name: 'nameWithoutType',
-              // type is missing
-            },
-          },
-        ],
-      },
-    };
-
-    expect(() => processManifestConfig(azionConfigWithTypeMissing)).toThrow(
-      "The 'name or type' field is required in the 'setOrigin' object.",
-    );
-  });
-
-  it('should throw an error for an undefined property', () => {
-    const azionConfigWithUndefinedProperty = {
-      cache: [
-        {
-          name: 'testCache',
-          undefinedProperty: 'This property does not exist',
+          ],
         },
-      ],
-    };
+      };
 
-    expect(() =>
-      processManifestConfig(azionConfigWithUndefinedProperty),
-    ).toThrow('No additional properties are allowed in cache item objects.');
-  });
+      const result = processManifestConfig(azionConfig);
+      // Checks if the forward_cookies behavior is included and set to true when forwardCookies is true
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'forward_cookies',
+            target: null, // Updated from 'params' to 'target'
+          }),
+        ]),
+      );
+    });
 
-  it('should correctly process the runFunction behavior with only the required path', () => {
-    const azionConfigWithRunFunctionOnlyPath = {
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/run-function-test-path-only',
-            runFunction: {
-              path: '.edge/worker.js',
+    it('should not include forward_cookies behavior when forwardCookies is false or not specified', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/no-forward',
+              forwardCookies: false,
             },
-          },
-        ],
-      },
-    };
+            {
+              name: 'testRule',
+              match: '/default-forward',
+              // forwardCookies not specified
+            },
+          ],
+        },
+      };
 
-    const expectedBehaviorPathOnly = {
-      target: '.edge/worker.js',
-    };
-
-    const resultPathOnly = processManifestConfig(
-      azionConfigWithRunFunctionOnlyPath,
-    );
-    expect(resultPathOnly.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining(expectedBehaviorPathOnly),
-      ]),
-    );
-  });
-  it('should include the behavior deliver when deliver is true', () => {
-    const azionConfigComDeliver = {
-      rules: {
-        request: [
+      const result = processManifestConfig(azionConfig);
+      // Checks if the forward_cookies behavior is not included when forwardCookies is false or not specified
+      expect(result.rules[0].behaviors).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'forward_cookies',
+          }),
+        ]),
+      );
+      expect(result.rules[1].behaviors).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'forward_cookies',
+          }),
+        ]),
+      );
+    });
+    it('should correctly process the setOrigin rule with all optional fields provided', () => {
+      const azionConfigWithAllFields = {
+        origin: [
           {
-            name: 'testRule',
-            match: '/path',
-            deliver: true,
+            name: 'my origin storage',
+            type: 'object_storage',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
           },
         ],
-      },
-    };
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/_next',
+              setOrigin: {
+                name: 'my origin storage',
+                type: 'object_storage',
+              },
+            },
+          ],
+        },
+      };
+      const resultWithAllFields = processManifestConfig(
+        azionConfigWithAllFields,
+      );
+      expect(resultWithAllFields.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'set_origin',
+            target: 'my origin storage',
+          }),
+        ]),
+      );
+    });
 
-    const result = processManifestConfig(azionConfigComDeliver);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'deliver',
-        }),
-      ]),
-    );
-  });
-  it('should throw an error if deliver is not a boolean', () => {
-    const azionConfig = {
-      rules: {
-        request: [
+    it('should throw an error when "type" is missing in "setOrigin"', () => {
+      const azionConfigWithTypeMissing = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/_next_no_type',
+              setOrigin: {
+                name: 'nameWithoutType',
+                // type is missing
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => processManifestConfig(azionConfigWithTypeMissing)).toThrow(
+        "The 'name or type' field is required in the 'setOrigin' object.",
+      );
+    });
+
+    it('should throw an error for an undefined property', () => {
+      const azionConfigWithUndefinedProperty = {
+        cache: [
           {
-            name: 'testRule',
-            match: '/path',
-            deliver: 'true', // Incorretamente definido como string
+            name: 'testCache',
+            undefinedProperty: 'This property does not exist',
           },
         ],
-      },
-    };
+      };
 
-    expect(() => processManifestConfig(azionConfig)).toThrow(
-      "The 'deliver' field must be a boolean or null.",
-    );
+      expect(() =>
+        processManifestConfig(azionConfigWithUndefinedProperty),
+      ).toThrow('No additional properties are allowed in cache item objects.');
+    });
+
+    it('should correctly process the runFunction behavior with only the required path', () => {
+      const azionConfigWithRunFunctionOnlyPath = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/run-function-test-path-only',
+              runFunction: {
+                path: '.edge/worker.js',
+              },
+            },
+          ],
+        },
+      };
+
+      const expectedBehaviorPathOnly = {
+        target: '.edge/worker.js',
+      };
+
+      const resultPathOnly = processManifestConfig(
+        azionConfigWithRunFunctionOnlyPath,
+      );
+      expect(resultPathOnly.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining(expectedBehaviorPathOnly),
+        ]),
+      );
+    });
+    it('should include the behavior deliver when deliver is true', () => {
+      const azionConfigComDeliver = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/path',
+              deliver: true,
+            },
+          ],
+        },
+      };
+
+      const result = processManifestConfig(azionConfigComDeliver);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'deliver',
+          }),
+        ]),
+      );
+    });
+    it('should throw an error if deliver is not a boolean', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/path',
+              deliver: 'true', // Incorretamente definido como string
+            },
+          ],
+        },
+      };
+
+      expect(() => processManifestConfig(azionConfig)).toThrow(
+        "The 'deliver' field must be a boolean or null.",
+      );
+    });
+
+    it('should throw an error if setCookie is not a string', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/',
+              setCookie: true, // Incorretamente definido como boolean
+            },
+          ],
+        },
+      };
+
+      expect(() => processManifestConfig(azionConfig)).toThrow(
+        "The 'setCookie' field must be a string or null.",
+      );
+    });
+
+    it('should throw an error if setHeaders is not a string', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/',
+              setHeaders: { key: 'value' }, // Incorretamente definido como objeto
+            },
+          ],
+        },
+      };
+
+      expect(() => processManifestConfig(azionConfig)).toThrow(
+        "The 'setHeaders' field must be a string or null.",
+      );
+    });
+
+    it('should correctly add deliver behavior when deliver is true', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/path',
+              deliver: true,
+            },
+          ],
+        },
+      };
+
+      const result = processManifestConfig(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'deliver',
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly add setCookie behavior with a valid string', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/',
+              setCookie: 'sessionId=abc123',
+            },
+          ],
+        },
+      };
+
+      const result = processManifestConfig(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'add_request_cookie',
+            target: 'sessionId=abc123',
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly add setHeaders behavior with a valid string', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/',
+              setHeaders: 'Authorization: Bearer abc123',
+            },
+          ],
+        },
+      };
+
+      const result = processManifestConfig(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'add_request_header',
+            target: 'Authorization: Bearer abc123',
+          }),
+        ]),
+      );
+    });
   });
 
-  it('should throw an error if setCookie is not a string', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/',
-            setCookie: true, // Incorretamente definido como boolean
-          },
-        ],
-      },
-    };
-
-    expect(() => processManifestConfig(azionConfig)).toThrow(
-      "The 'setCookie' field must be a string or null.",
-    );
-  });
-
-  it('should throw an error if setHeaders is not a string', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/',
-            setHeaders: { key: 'value' }, // Incorretamente definido como objeto
-          },
-        ],
-      },
-    };
-
-    expect(() => processManifestConfig(azionConfig)).toThrow(
-      "The 'setHeaders' field must be a string or null.",
-    );
-  });
-
-  it('should correctly add deliver behavior when deliver is true', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/path',
-            deliver: true,
-          },
-        ],
-      },
-    };
-
-    const result = processManifestConfig(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'deliver',
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly add setCookie behavior with a valid string', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/',
-            setCookie: 'sessionId=abc123',
-          },
-        ],
-      },
-    };
-
-    const result = processManifestConfig(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'add_request_cookie',
-          target: 'sessionId=abc123',
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly add setHeaders behavior with a valid string', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/',
-            setHeaders: 'Authorization: Bearer abc123',
-          },
-        ],
-      },
-    };
-
-    const result = processManifestConfig(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'add_request_header',
-          target: 'Authorization: Bearer abc123',
-        }),
-      ]),
-    );
-  });
-
-  describe('Origin - processManifestConfig', () => {
+  describe('processManifestConfig - Origin', () => {
     it('should process the manifest config when the origin name and type are the same as the rules setOrigin name and type', () => {
       const azionConfig = {
         origin: [


### PR DESCRIPTION
When generating the manifest, a temporary file is now created due to generation steps. 
`Loadash` was also used to merge the configurations.