### PR TITLE
feat: eject azion.config.js file

### DIFF
--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -123,7 +123,7 @@ class Dispatcher {
    * @returns {object} - Preset files
    */
   async loadPreset() {
-    feedback.build.info('Loading build context ...');
+    feedback.build.info('Loading build context...');
 
     const VALID_BUILD_PRESETS = presets.getKeys();
     const vulcanRootPath = resolve(this.vulcanLibPath, '..');

--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -343,13 +343,10 @@ class Dispatcher {
   }
 
   static async generateFinalManifest() {
-    feedback.build.info('Checking Azion CDN configuration file...');
+    feedback.build.info('Checking Azion configuration file...');
     const buildConfigPath = join(process.cwd(), 'azion.config.js');
-    let vulcanCustomConfigModule = {};
-    if (existsSync(buildConfigPath)) {
-      vulcanCustomConfigModule = (await import(buildConfigPath)).default;
-    }
-    await generateManifest(vulcanCustomConfigModule, true);
+    const vulcanCustomConfigModule = (await import(buildConfigPath)).default;
+    await generateManifest(vulcanCustomConfigModule);
     feedback.build.success('Manifest generated successfully.');
   }
 

--- a/lib/notations/namespaces.js
+++ b/lib/notations/namespaces.js
@@ -6,12 +6,6 @@
 const Utils = {};
 
 /**
- * @namespace Platform
- * @description Contains functions and actions to interact with the edge platform (Azion).
- */
-const Platform = {};
-
-/**
  * @namespace Build
  * @description Represents the structure responsible for pre-build and build processes for the edge.
  */
@@ -48,20 +42,4 @@ const Commands = {};
  */
 const Polyfills = {};
 
-/**
- * @namespace Services
- * @description Azion Platform Services.
- */
-const Services = {};
-
-export {
-  Utils,
-  Platform,
-  Build,
-  Env,
-  Presets,
-  Edge,
-  Polyfills,
-  Commands,
-  Services,
-};
+export { Utils, Build, Env, Presets, Edge, Polyfills, Commands };

--- a/lib/utils/feedback/feedback.utils.js
+++ b/lib/utils/feedback/feedback.utils.js
@@ -40,9 +40,9 @@ const methods = {
     logLevel: 'info',
   },
   option: {
-    badge: '🟣',
-    color: 'magenta',
-    label: 'option',
+    badge: '🌋',
+    color: 'green',
+    label: '',
     logLevel: 'info',
   },
 };
@@ -103,33 +103,6 @@ const scopes = {
     interactive: getLogger({
       interactive: true,
       scope: ['Vulcan', 'Postbuild'],
-      types: methods,
-    }),
-  },
-  platform: {
-    ...global.scope('Vulcan', 'Platform'),
-    interactive: getLogger({
-      interactive: true,
-      scope: ['Vulcan', 'Platform'],
-      types: methods,
-    }),
-  },
-  statics: {
-    ...global.scope('Vulcan', 'Storage'),
-    interactive: getLogger({
-      interactive: true,
-      scope: ['Vulcan', 'storage'],
-      types: methods,
-    }),
-  },
-  logs: (scope1, scope2, scope3) => ({
-    ...global.scope('Azion', `${scope1}`, scope2, scope3),
-  }),
-  propagation: {
-    ...global.scope('Azion', 'Edge Network'),
-    interactive: getLogger({
-      interactive: true,
-      scope: ['Vulcan', 'Azion Network'],
       types: methods,
     }),
   },

--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -1,4 +1,4 @@
-import { writeFileSync, existsSync, mkdirSync } from 'fs';
+import { writeFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import Ajv from 'ajv';
 import ajvErrors from 'ajv-errors';
@@ -275,6 +275,21 @@ async function loadAzionConfig(configPath, configModule) {
 }
 
 /**
+ * Determines if the project uses the CommonJS module system by default.
+ * It checks the 'type' key in the 'package.json' file at the project root.
+ * If 'type' is 'commonjs' or absent, returns true. Otherwise, returns false.
+ * @returns {boolean} True if the project uses CommonJS, false if it uses ES Modules.
+ */
+function useCommonJS() {
+  const packageJsonPath = join(process.cwd(), 'package.json');
+  if (existsSync(packageJsonPath)) {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    return packageJson.type !== 'module'; // Returns true for 'commonjs' or no 'type' specified
+  }
+  return true; // Default to CommonJS if 'package.json' does not exist or 'type' key is absent
+}
+
+/**
  * Generates or updates the CDN manifest based on a custom configuration module.
  * If an existing manifest is found, it merges the configurations, prioritizing the custom module.
  * This function is typically called during the prebuild stage to prepare the CDN configuration.
@@ -286,7 +301,6 @@ async function generateManifest(configModule) {
   const dotEdgeDir = join(process.cwd(), '.edge');
   const finalManifestPath = join(dotEdgeDir, 'manifest.json');
 
-  // in case it is run during prebuild
   if (!existsSync(dotEdgeDir)) {
     mkdirSync(dotEdgeDir);
   }
@@ -295,9 +309,12 @@ async function generateManifest(configModule) {
   const manifest = processManifestConfig(AzionConfig);
 
   if (!existsSync(configPath)) {
+    const moduleExportStyle = useCommonJS()
+      ? 'module.exports ='
+      : 'export default';
     writeFileSync(
       configPath,
-      `export default ${JSON.stringify(AzionConfig, null, 2)};`,
+      `${moduleExportStyle} ${JSON.stringify(AzionConfig, null, 2)};`,
     );
   }
 

--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -1,14 +1,10 @@
-import { existsSync, writeFileSync, readFileSync, mkdirSync, rm } from 'fs';
+import { writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import Ajv from 'ajv';
 import ajvErrors from 'ajv-errors';
 import addKeywords from 'ajv-keywords';
-import os from 'node:os';
-import lodash from 'lodash';
 
 import azionConfigSchema from './fixtures/schema.js';
-import debug from '../debug/debug.utils.js';
-
 /**
  * Validates the provided configuration against a JSON Schema.
  * This function uses AJV (Another JSON Schema Validator) to validate the configuration.
@@ -253,34 +249,29 @@ function processManifestConfig(config) {
 }
 
 /**
- * Removes the temporary folder used to store the manifest file.
- * This function is typically called after the manifest is generated and copied to the edge directory.
+ * Loads the Azion deploy configuration from a local file or a provided module.
+ * If a custom configuration file 'azion.config.js' exists in the root directory, it takes precedence and is loaded.
+ * If the file does not exist, the function will attempt to use the provided configuration module.
+ * If no module is provided, a minimal default configuration is returned.
+ * @param {string} configPath - The path to the custom configuration file.
+ * @param {object} configModule - An alternative configuration module provided as a fallback.
+ * @returns {Promise<object>} A promise that resolves to the loaded configuration object.
  */
-function removeTmpFolder() {
-  const manifestPath = globalThis.vulcan.tmpManifestFile;
-  if (manifestPath) {
-    const dirName = manifestPath.substring(0, manifestPath.lastIndexOf('/'));
-    rm(dirName, { recursive: true }, (err) => {
-      if (err) {
-        debug.error(err);
-      }
-    });
-  }
-  globalThis.vulcan.tmpManifestFile = null;
-}
+async function loadAzionConfig(configPath, configModule) {
+  const existCustomAzionConfig = existsSync(configPath); // user created azion.config.js in root directory
 
-/**
- * Create the final manifest file to the edge directory.
- */
-async function generateFinalManifest() {
-  const manifestPath = globalThis.vulcan.tmpManifestFile;
-  const finalManifestPath = join(process.cwd(), '.edge', 'manifest.json');
-  if (existsSync(manifestPath)) {
-    writeFileSync(finalManifestPath, readFileSync(manifestPath));
-    removeTmpFolder();
-  } else {
-    throw new Error('Manifest file not found');
+  // the file created has priorty over preset
+  if (existCustomAzionConfig) {
+    return (await import(configPath)).default;
   }
+  if (!existCustomAzionConfig && configModule) {
+    return configModule;
+  }
+  return {
+    rules: {
+      request: [{}], // minimal configuration
+    },
+  };
 }
 
 /**
@@ -288,64 +279,29 @@ async function generateFinalManifest() {
  * If an existing manifest is found, it merges the configurations, prioritizing the custom module.
  * This function is typically called during the prebuild stage to prepare the CDN configuration.
  * @param {object} configModule - The custom configuration module provided by the user.
- * @param {boolean} shouldGenerateFinalManifest - A flag indicating whether the final manifest should be generated after the temporary manifest is created.
  * @async
  */
-async function generateManifest(
-  configModule,
-  shouldGenerateFinalManifest = false,
-) {
-  const edgeDirPath = join(process.cwd(), '.edge');
-  const tmpDirPath = join(os.tmpdir(), 'vulcan');
+async function generateManifest(configModule) {
+  const configPath = join(process.cwd(), 'azion.config.js');
+  const dotEdgeDir = join(process.cwd(), '.edge');
+  const finalManifestPath = join(dotEdgeDir, 'manifest.json');
 
-  if (!existsSync(tmpDirPath)) {
-    mkdirSync(tmpDirPath);
+  // in case it is run during prebuild
+  if (!existsSync(dotEdgeDir)) {
+    mkdirSync(dotEdgeDir);
   }
 
-  let manifestPath = globalThis.vulcan.tmpManifestFile;
-  if (!manifestPath) {
-    manifestPath = join(tmpDirPath, `manifest-${new Date().getTime()}.json`);
-    globalThis.vulcan.tmpManifestFile = manifestPath;
+  const AzionConfig = await loadAzionConfig(configPath, configModule);
+  const manifest = processManifestConfig(AzionConfig);
+
+  if (!existsSync(configPath)) {
+    writeFileSync(
+      configPath,
+      `export default ${JSON.stringify(AzionConfig, null, 2)};`,
+    );
   }
 
-  //  preset configuration (existingManifest) have priority over user azion.config.js
-  let existingManifest = {};
-
-  if (!existsSync(edgeDirPath)) {
-    mkdirSync(edgeDirPath);
-  }
-
-  if (existsSync(manifestPath)) {
-    const existingManifestRaw = readFileSync(manifestPath, 'utf8');
-    existingManifest = JSON.parse(existingManifestRaw);
-  }
-
-  const newManifestConfig = processManifestConfig(configModule);
-
-  // eslint-disable-next-line
-  function customizer(objValue, srcValue) {
-    if (Array.isArray(objValue)) {
-      return objValue.concat(
-        srcValue.filter(
-          (srcItem) =>
-            !objValue.some((objItem) => objItem?.name === srcItem?.name),
-        ),
-      );
-    }
-  }
-
-  // Merge the new configuration with the existing manifest with priority to the existing manifest
-  const mergeManifest = lodash.mergeWith(
-    existingManifest,
-    newManifestConfig,
-    customizer,
-  );
-
-  writeFileSync(manifestPath, JSON.stringify(mergeManifest, null, 2));
-
-  if (shouldGenerateFinalManifest) {
-    await generateFinalManifest();
-  }
+  writeFileSync(finalManifestPath, JSON.stringify(manifest, null, 2));
 }
 
 export { processManifestConfig, generateManifest };

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -1,113 +1,7 @@
 import { describe, expect } from '@jest/globals';
-import { readFileSync } from 'node:fs';
-import mockFs from 'mock-fs';
-import {
-  generateManifest,
-  processManifestConfig,
-} from './generateManifest.utils.js';
+import { processManifestConfig } from './generateManifest.utils.js';
 
 describe('Utils - generateManifest', () => {
-  it('should correctly merge config when generateManifest is called multiple times', async () => {
-    globalThis.vulcan = {};
-    const presetConfig = {
-      rules: {
-        request: [
-          {
-            name: 'Main_Rule',
-            match: '^\\/',
-            runFunction: {
-              path: '.edge/worker.js',
-            },
-          },
-        ],
-      },
-    };
-    const azionConfig = {
-      origin: [
-        {
-          name: 'my origin storage',
-          type: 'object_storage',
-          bucket: 'mybucket',
-          prefix: 'myfolder',
-        },
-      ],
-      rules: {
-        request: [
-          {
-            name: 'my-rule-origin',
-            match: '/^/_statics/;',
-            setOrigin: {
-              name: 'my origin storage',
-              type: 'object_storage',
-            },
-          },
-        ],
-      },
-    };
-    mockFs({
-      '.edge/manifest.json': '{}',
-    });
-    await generateManifest(presetConfig);
-    await generateManifest(azionConfig, true);
-    const manifest = readFileSync('.edge/manifest.json', 'utf8');
-    mockFs.restore();
-    expect(JSON.parse(manifest)).toEqual(
-      expect.objectContaining({
-        origin: expect.arrayContaining([
-          {
-            name: 'my origin storage',
-            origin_type: 'object_storage',
-            bucket: 'mybucket',
-            prefix: 'myfolder',
-          },
-        ]),
-        rules: expect.arrayContaining([
-          {
-            name: 'my-rule-origin',
-            criteria: [
-              [
-                {
-                  // eslint-disable-next-line no-template-curly-in-string
-                  variable: '${uri}',
-                  operator: 'matches',
-                  conditional: 'if',
-                  input_value: '/^/_statics/;',
-                },
-              ],
-            ],
-            behaviors: [
-              {
-                name: 'set_origin',
-                target: 'my origin storage',
-              },
-            ],
-          },
-          {
-            name: 'Main_Rule',
-            criteria: [
-              [
-                {
-                  // eslint-disable-next-line no-template-curly-in-string
-                  variable: '${uri}',
-                  operator: 'matches',
-                  conditional: 'if',
-                  input_value: '^\\/',
-                },
-              ],
-            ],
-            behaviors: [
-              {
-                name: 'run_function',
-                target: '.edge/worker.js',
-              },
-            ],
-          },
-        ]),
-        cache: [],
-      }),
-    );
-  });
-
   describe('processManifestConfig', () => {
     it('should throw an error for invalid mathematical expressions', () => {
       const azionConfig = {
@@ -173,10 +67,19 @@ describe('Utils - generateManifest', () => {
       const result = processManifestConfig(azionConfig);
       expect(result.rules[0].behaviors).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({
-            name: 'rewrite_request',
-            target: expect.stringContaining('/%{other[0]}/%{other[1]}'), // Updated from 'params' to 'target'
-          }),
+          expect.objectContaining(
+            {
+              name: 'capture_match_groups',
+              target: {
+                captured_array: 'other',
+                regex: '^(./)([^/])$',
+                // eslint-disable-next-line no-template-curly-in-string
+                subject: '${uri}',
+              },
+            },
+            // eslint-disable-next-line no-template-curly-in-string
+            { name: 'rewrite_request', target: '/${other[0]}/${other[1]}' },
+          ),
         ]),
       );
     });


### PR DESCRIPTION

This PR implements the ejection of `azion.config.js`. Now whenever the build is done, this file will be created in the project directory containing the preset configurations to run on Azion (azion.config.js).


**The reason is to make it clear what the rules engine are and how they work.**


Bonus: fixes some things that were left behind.