### PR TITLE
fix: process env support at runtime

### DIFF
--- a/lib/build/bundlers/polyfills/node/globals/process.cjs
+++ b/lib/build/bundlers/polyfills/node/globals/process.cjs
@@ -1,6 +1,6 @@
 /* eslint-disable */
 // shim for using process in browser
-var process = (module.exports = {});
+var processShim = (module.exports = {});
 
 /*
  * Copyright Azion
@@ -137,7 +137,7 @@ function drainQueue() {
   runClearTimeout(timeout);
 }
 
-process.nextTick = function (fun) {
+processShim.nextTick = function (fun) {
   var args = new Array(arguments.length - 1);
   if (arguments.length > 1) {
     for (var i = 1; i < arguments.length; i++) {
@@ -158,43 +158,46 @@ function Item(fun, array) {
 Item.prototype.run = function () {
   this.fun.apply(null, this.array);
 };
-process.title = 'browser';
-process.browser = true;
-process.env = {};
-process.argv = [];
-process.version = ''; // empty string to avoid regexp issues
-process.versions = { node: '18.3.1' };
+processShim.title = 'browser';
+processShim.browser = true;
+processShim.env = processShim.env =
+  typeof globalThis.process !== 'undefined' && globalThis.process.env
+    ? globalThis.process.env
+    : {};
+processShim.argv = [];
+processShim.version = ''; // empty string to avoid regexp issues
+processShim.versions = { node: '18.3.1' };
 
 function noop() {}
 
-process.on = noop;
-process.addListener = noop;
-process.once = noop;
-process.off = noop;
-process.removeListener = noop;
-process.removeAllListeners = noop;
-process.emit = noop;
-process.prependListener = noop;
-process.prependOnceListener = noop;
+processShim.on = noop;
+processShim.addListener = noop;
+processShim.once = noop;
+processShim.off = noop;
+processShim.removeListener = noop;
+processShim.removeAllListeners = noop;
+processShim.emit = noop;
+processShim.prependListener = noop;
+processShim.prependOnceListener = noop;
 
-process.listeners = function (name) {
+processShim.listeners = function (name) {
   return [];
 };
 
-process.binding = function (name) {
+processShim.binding = function (name) {
   throw new Error('process.binding is not supported');
 };
 
-process.cwd = function () {
+processShim.cwd = function () {
   return '/';
 };
 
-process.chdir = function (dir) {
+processShim.chdir = function (dir) {
   throw new Error('process.chdir is not supported');
 };
-process.umask = function () {
+processShim.umask = function () {
   return 0;
 };
 
-globalThis.process = process;
-globalThis.process.env ??= {};
+globalThis.process = processShim;
+globalThis.process.env = processShim.env;


### PR DESCRIPTION
Change for process env support in Runtime.
Now the process env is checked before initialization and if it exists it is loaded, if not it is defined with a new object.