### PR TITLE
chore: improve watcher

### DIFF
--- a/lib/env/server.env.js
+++ b/lib/env/server.env.js
@@ -205,7 +205,7 @@ async function startServer(workerPath, isFirewall, port) {
     .on('unlinkDir', handleUserFileChange)
     .on('error', (error) => debug.error(`Watcher error: ${error}`))
     .on('ready', () =>
-      feedback.server.info('Initial scan complete. Ready for changes'),
+      feedback.server.info('Initial scan complete. Ready for changes.'),
     );
 }
 

--- a/lib/env/server.env.js
+++ b/lib/env/server.env.js
@@ -188,15 +188,25 @@ async function startServer(workerPath, isFirewall, port) {
 
   const watcher = chokidar.watch('./', {
     persistent: true,
-    ignoreInitial: false,
+    ignoreInitial: true, // Ignore the initial add events
     depth: 99,
+    ignored: ['.git', '.vscode', '.idea', '.sublime-text', '.history'], // Added common IDE-related folders
   });
 
-  watcher.on('change', async (path) => {
+  const handleUserFileChange = async (path) => {
     await handleFileChange(path, workerPath, port, isFirewall);
-  });
+  };
 
-  watcher.on('error', (error) => debug.error(`Watcher error: ${error}`));
+  watcher
+    .on('add', handleUserFileChange)
+    .on('change', handleUserFileChange)
+    .on('unlink', handleUserFileChange)
+    .on('addDir', handleUserFileChange)
+    .on('unlinkDir', handleUserFileChange)
+    .on('error', (error) => debug.error(`Watcher error: ${error}`))
+    .on('ready', () =>
+      feedback.server.info('Initial scan complete. Ready for changes'),
+    );
 }
 
 export default startServer;


### PR DESCRIPTION
This solves #330 

1. Set ignoreInitial to true to prevent double execution of watcher actions. This avoids triggering actions when the first build changes files that are being watched but should not trigger any action.

2. Introduced an ignored list to prevent watcher actions when IDEs change non-source files.

3. Defined only the essential filesystem actions to monitor. 

4. Added feedback indicating that a watcher is in place.

Please review the changes. Let me know if further modifications are needed.