### PR TITLE
fix: add missing packages for jekyll in the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apk upgrade --no-cache --update
 
 RUN apk add linux-headers alpine-sdk
 
+RUN apk add build-base g++
+
 RUN apk add ruby-dev
 
 RUN gem install jekyll bundler


### PR DESCRIPTION
The Jekyll preset was failing to build due to missing dependencies.