### PR TITLE
Feat: Handle files to fs

### DIFF
--- a/lib/build/dispatcher/dispatcher.js
+++ b/lib/build/dispatcher/dispatcher.js
@@ -14,6 +14,7 @@ import {
   injectFilesInMem,
   helperHandlerCode,
   generateManifest,
+  copyFilesToFS,
 } from '#utils';
 import { Messages } from '#constants';
 import vulcan from '../../env/vulcan.env.js';
@@ -409,6 +410,7 @@ class Dispatcher {
     const { injectionDirs, removePathPrefix } = buildConfig.memoryFS;
     if (injectionDirs && injectionDirs.length > 0) {
       const content = await injectFilesInMem(injectionDirs);
+      copyFilesToFS(injectionDirs);
 
       const prefix =
         removePathPrefix &&

--- a/lib/utils/copyFilesToFS/copyFilesToFS.utils.js
+++ b/lib/utils/copyFilesToFS/copyFilesToFS.utils.js
@@ -1,0 +1,15 @@
+import copyDirectory from '../copyDirectory/index.js';
+
+/**
+ * Copy files to directory ./edge/storage, so this files are uploaded to client's bucket.
+ * @param {string[]} dirs - The directories to be copied to the FS.
+ */
+function copyFilesToFS(dirs) {
+  const edgeStorageDir = '.edge/storage';
+
+  dirs.forEach((dir) => {
+    copyDirectory(dir, `${edgeStorageDir}/${dir}`);
+  });
+}
+
+export default copyFilesToFS;

--- a/lib/utils/copyFilesToFS/copyFilesToFS.utils.test.js
+++ b/lib/utils/copyFilesToFS/copyFilesToFS.utils.test.js
@@ -1,0 +1,44 @@
+import mockFs from 'mock-fs';
+import fs from 'fs';
+import copyFilesToFS from './copyFilesToFS.utils.js';
+
+describe('copyFilesToFS', () => {
+  beforeEach(() => {
+    mockFs({
+      dir1: {
+        'file1.txt': 'content1',
+      },
+      dir2: {
+        'file2.txt': 'content2',
+        subdir: {
+          'file3.txt': 'content3',
+        },
+      },
+      '.edge/storage': {},
+    });
+  });
+
+  afterEach(() => {
+    mockFs.restore();
+  });
+
+  it('should copy directories to .edge/storage', () => {
+    const dirs = ['dir1', 'dir2'];
+    copyFilesToFS(dirs);
+
+    expect(fs.existsSync('.edge/storage/dir1/file1.txt')).toBe(true);
+    expect(fs.readFileSync('.edge/storage/dir1/file1.txt', 'utf8')).toBe(
+      'content1',
+    );
+
+    expect(fs.existsSync('.edge/storage/dir2/file2.txt')).toBe(true);
+    expect(fs.readFileSync('.edge/storage/dir2/file2.txt', 'utf8')).toBe(
+      'content2',
+    );
+
+    expect(fs.existsSync('.edge/storage/dir2/subdir/file3.txt')).toBe(true);
+    expect(fs.readFileSync('.edge/storage/dir2/subdir/file3.txt', 'utf8')).toBe(
+      'content3',
+    );
+  });
+});

--- a/lib/utils/copyFilesToFS/index.js
+++ b/lib/utils/copyFilesToFS/index.js
@@ -1,0 +1,3 @@
+import copyFilesToFS from './copyFilesToFS.utils.js';
+
+export default copyFilesToFS;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -20,6 +20,7 @@ import getExportedFunctionBody from './getExportedFunctionBody/index.js';
 import injectFilesInMem from './injectFilesInMem/index.js';
 import helperHandlerCode from './helperHandlerCode/index.js';
 import generateManifest from './generateManifest/index.js';
+import copyFilesToFS from './copyFilesToFS/index.js';
 
 export {
   copyDirectory,
@@ -44,4 +45,5 @@ export {
   injectFilesInMem,
   helperHandlerCode,
   generateManifest,
+  copyFilesToFS,
 };


### PR DESCRIPTION
This PR adds the function that copies the files defined in the "injectionDirs" parameter of vulcan.config.js" to the .edge/storage folder.