### PR TITLE
feat: adding support for domains in manifest generation.

### DIFF
--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -9,6 +9,7 @@ import ManifestContext from './strategy/manifestContext.js';
 import OriginManifestStrategy from './strategy/implementations/originManifestStrategy.js';
 import CacheManifestStrategy from './strategy/implementations/cacheManifestStrategy.js';
 import RulesManifestStrategy from './strategy/implementations/rulesManifestStrategy.js';
+import DomainManisfestStrategy from './strategy/implementations/domainManifestStrategy.js';
 
 /**
  * Validates the provided configuration against a JSON Schema.
@@ -47,6 +48,8 @@ function jsToJson(inputConfig) {
   const manifestContext = new ManifestContext();
   manifestContext.setStrategy('origin', new OriginManifestStrategy());
   manifestContext.setStrategy('cache', new CacheManifestStrategy());
+  manifestContext.setStrategy('domain', new DomainManisfestStrategy());
+
   // Rules must be last to apply to behaviors (origin, cache...)
   manifestContext.setStrategy('rules', new RulesManifestStrategy());
   manifestContext.generate(config, payloadCDN);

--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -4,8 +4,11 @@ import ajvErrors from 'ajv-errors';
 import addKeywords from 'ajv-keywords';
 
 import azionConfigSchema from './helpers/schema.js';
-import { requestBehaviors, responseBehaviors } from './helpers/behaviors.js';
 import convertLegacyConfig from './helpers/convertLegacyConfig.js';
+import ManifestContext from './strategy/manifestContext.js';
+import OriginManifestStrategy from './strategy/implementations/originManifestStrategy.js';
+import CacheManifestStrategy from './strategy/implementations/cacheManifestStrategy.js';
+import RulesManifestStrategy from './strategy/implementations/rulesManifestStrategy.js';
 
 /**
  * Validates the provided configuration against a JSON Schema.
@@ -38,181 +41,15 @@ function jsToJson(inputConfig) {
   const config = convertLegacyConfig(inputConfig);
   validateConfig(config);
 
-  const payloadCDN = {
-    origin: [],
-    cache: [],
-    rules: [],
-  };
+  const payloadCDN = {};
 
-  // Helper function to safely evaluate mathematical expressions
-  const evaluateMathExpression = (expression) => {
-    if (typeof expression === 'number') {
-      return expression;
-    }
-    if (/^[0-9+\-*/.() ]+$/.test(expression)) {
-      // eslint-disable-next-line no-eval
-      return eval(expression);
-    }
-    throw new Error(`Expression is not purely mathematical: ${expression}`);
-  };
-
-  // Convert origin settings
-  if (config && config.origin && config.origin.length > 0) {
-    config.origin.forEach((origin) => {
-      if (origin.type !== 'object_storage' && origin.type !== 'single_origin') {
-        throw new Error(
-          `Rule setOrigin originType '${origin.type}' is not supported`,
-        );
-      }
-      const originSetting = {
-        name: origin.name,
-        origin_type: origin.type,
-      };
-
-      if (origin.type === 'object_storage') {
-        originSetting.bucket = origin.bucket;
-        originSetting.prefix = origin.prefix;
-      }
-      if (origin.type === 'single_origin') {
-        originSetting.addresses = origin.addresses?.map((address) => {
-          return { address };
-        });
-        originSetting.host_header = origin.hostHeader;
-      }
-      payloadCDN.origin.push(originSetting);
-    });
-  }
-
-  // Convert cache settings
-  if (config && config.cache && config.cache.length > 0) {
-    config.cache.forEach((cache) => {
-      const maxAgeSecondsBrowser = cache?.browser
-        ? evaluateMathExpression(cache.browser.maxAgeSeconds)
-        : 0;
-      const maxAgeSecondsEdge = cache?.edge
-        ? evaluateMathExpression(cache.edge.maxAgeSeconds)
-        : 60;
-
-      const cacheSetting = {
-        name: cache.name,
-        browser_cache_settings: cache?.browser ? 'override' : 'honor',
-        browser_cache_settings_maximum_ttl: maxAgeSecondsBrowser,
-        cdn_cache_settings: cache?.edge ? 'override' : 'honor',
-        cdn_cache_settings_maximum_ttl: maxAgeSecondsEdge,
-        enable_caching_for_post: cache?.methods?.post || false,
-        enable_caching_for_options: cache?.methods?.options || false,
-        enable_query_string_sort: cache?.queryStringSort || false,
-      };
-
-      if (cache.cacheByQueryString) {
-        cacheSetting.cache_by_query_string =
-          cache.cacheByQueryString.option === 'varies'
-            ? 'all'
-            : cache.cacheByQueryString.option;
-        if (
-          cache.cacheByQueryString.option === 'whitelist' ||
-          cache.cacheByQueryString.option === 'blacklist'
-        ) {
-          cacheSetting.query_string_fields =
-            cache.cacheByQueryString.list || [];
-        } else {
-          cacheSetting.query_string_fields = [];
-        }
-      }
-
-      if (cache.cacheByCookie) {
-        cacheSetting.cache_by_cookie =
-          cache.cacheByCookie.option === 'varies'
-            ? 'all'
-            : cache.cacheByCookie.option;
-        if (
-          cache.cacheByCookie.option === 'whitelist' ||
-          cache.cacheByCookie.option === 'blacklist'
-        ) {
-          cacheSetting.cookie_names = cache.cacheByCookie.list || [];
-        } else {
-          cacheSetting.cookie_names = [];
-        }
-      }
-
-      payloadCDN.cache.push(cacheSetting);
-    });
-  }
-
-  // Helper function to add behaviors to a rule
-  const addBehaviors = (cdnRule, behaviors, behaviorDefinitions) => {
-    if (behaviors && typeof behaviors === 'object') {
-      Object.entries(behaviors).forEach(([key, value]) => {
-        if (behaviorDefinitions[key]) {
-          const transformedBehavior = behaviorDefinitions[key].transform(
-            value,
-            payloadCDN,
-          );
-          if (Array.isArray(transformedBehavior)) {
-            cdnRule.behaviors.push(...transformedBehavior);
-          } else if (transformedBehavior) {
-            cdnRule.behaviors.push(transformedBehavior);
-          }
-        } else {
-          console.warn(`Unknown behavior: ${key}`);
-        }
-      });
-    }
-  };
-
-  // Convert request rules
-  config?.rules?.request?.forEach((rule, index) => {
-    const cdnRule = {
-      name: rule.name,
-      phase: 'request',
-      description: rule.description ?? '',
-      is_active: rule.active !== undefined ? rule.active : true, // Default to true if not provided
-      order: index + 2, // index starts at 2, because the default rule is index 1
-      criteria: [
-        [
-          {
-            variable: `\${${rule.variable ?? 'uri'}}`,
-            operator: 'matches',
-            conditional: 'if',
-            input_value: rule.match,
-          },
-        ],
-      ],
-      behaviors: [],
-    };
-
-    addBehaviors(cdnRule, rule.behavior, requestBehaviors);
-
-    payloadCDN.rules.push(cdnRule);
-  });
-
-  // Convert response rules
-  if (config?.rules?.response) {
-    config.rules.response.forEach((rule, index) => {
-      const cdnRule = {
-        name: rule.name,
-        phase: 'response',
-        description: rule.description ?? '',
-        is_active: rule.active !== undefined ? rule.active : true, // Default to true if not provided
-        order: index + 2, // index starts at 2, because the default rule is index 1
-        criteria: [
-          [
-            {
-              variable: `\${${rule.variable ?? 'uri'}}`,
-              operator: 'matches',
-              conditional: 'if',
-              input_value: rule.match,
-            },
-          ],
-        ],
-        behaviors: [],
-      };
-
-      addBehaviors(cdnRule, rule.behavior, responseBehaviors);
-
-      payloadCDN.rules.push(cdnRule);
-    });
-  }
+  // Manifest Strategy Pattern
+  const manifestContext = new ManifestContext();
+  manifestContext.setStrategy('origin', new OriginManifestStrategy());
+  manifestContext.setStrategy('cache', new CacheManifestStrategy());
+  // Rules must be last to apply to behaviors (origin, cache...)
+  manifestContext.setStrategy('rules', new RulesManifestStrategy());
+  manifestContext.generate(config, payloadCDN);
 
   return payloadCDN;
 }

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -1,4 +1,4 @@
-import { describe, expect } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { jsToJson } from './generateManifest.utils.js';
 
 describe('Utils - generateManifest', () => {
@@ -748,755 +748,1072 @@ describe('Utils - generateManifest', () => {
     });
   });
 
-  it('should correctly handle bypassCache behavior', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testBypassCache',
-            match: '/',
-            behavior: {
-              bypassCache: true,
-            },
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'bypass_cache_phase',
-          target: null,
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly handle redirect to 301', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testRedirect301',
-            match: '/',
-            behavior: {
-              redirectTo301: 'https://example.com',
-            },
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'redirect_to_301',
-          target: 'https://example.com',
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly handle redirect to 302', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testRedirect302',
-            match: '/',
-            behavior: {
-              redirectTo302: 'https://example.com',
-            },
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'redirect_to_302',
-          target: 'https://example.com',
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly handle capture match groups', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'testCapture',
-            match: '/',
-            behavior: {
-              capture: {
-                match: '^/user/(.*)',
-                captured: 'userId',
-                subject: 'uri',
+  describe('jsToJson - Rules', () => {
+    it('should correctly handle bypassCache behavior', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testBypassCache',
+              match: '/',
+              behavior: {
+                bypassCache: true,
               },
             },
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'capture_match_groups',
-          target: {
-            regex: '^/user/(.*)',
-            captured_array: 'userId',
-            // eslint-disable-next-line no-template-curly-in-string
-            subject: '${uri}',
-          },
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly handle filterCookie behavior', () => {
-    const azionConfig = {
-      rules: {
-        response: [
-          {
-            name: 'testFilterCookie',
-            match: '/',
-            behavior: {
-              filterCookie: '_cookie',
-            },
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'filter_response_cookie',
-          target: '_cookie',
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly process rules in the response phase', () => {
-    const azionConfig = {
-      rules: {
-        response: [
-          {
-            name: 'testResponsePhase',
-            match: '/',
-            behavior: {
-              setHeaders: ['X-Test-Header: value'],
-            },
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'add_response_header',
-          target: 'X-Test-Header: value',
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly add multiple response headers', () => {
-    const azionConfig = {
-      rules: {
-        response: [
-          {
-            name: 'testMultipleHeaders',
-            match: '/',
-            behavior: {
-              setHeaders: [
-                'X-Frame-Options: DENY',
-                "Content-Security-Policy: default-src 'self'",
-              ],
-            },
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'add_response_header',
-          target: 'X-Frame-Options: DENY',
-        }),
-        expect.objectContaining({
-          name: 'add_response_header',
-          target: "Content-Security-Policy: default-src 'self'",
-        }),
-      ]),
-    );
-  });
-
-  it('should correctly handle enableGZIP behavior', () => {
-    const azionConfig = {
-      rules: {
-        response: [
-          {
-            name: 'testEnableGZIP',
-            match: '/',
-            behavior: {
-              enableGZIP: true,
-            },
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'enable_gzip',
-          target: '',
-        }),
-      ]),
-    );
-  });
-
-  it('should handle rules with description and active properties correctly', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          {
-            name: 'Example Rule',
-            match: '/',
-            description: 'This rule redirects all traffic.',
-            active: false,
-          },
-          {
-            name: 'Second Rule',
-            match: '/api',
-            behavior: {},
-            // description is not provided here
-            active: true,
-          },
-          {
-            name: 'Third Rule',
-            match: '/home',
-            description: 'This rule handles home traffic.',
-            behavior: {},
-            // active is not provided here
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules).toEqual([
-      expect.objectContaining({
-        name: 'Example Rule',
-        description: 'This rule redirects all traffic.',
-        is_active: false,
-      }),
-      expect.objectContaining({
-        name: 'Second Rule',
-        description: '', // Should default to an empty string
-        is_active: true,
-      }),
-      expect.objectContaining({
-        name: 'Third Rule',
-        description: 'This rule handles home traffic.',
-        is_active: true, // Should default to true
-      }),
-    ]);
-  });
-
-  it('should correctly assign order starting from 2 for request and response rules', () => {
-    const azionConfig = {
-      rules: {
-        request: [
-          { name: 'First Request Rule', match: '/', behavior: {} },
-          { name: 'Second Request Rule', match: '/second', behavior: {} },
-        ],
-        response: [
-          { name: 'First Response Rule', match: '/', behavior: {} },
-          { name: 'Second Response Rule', match: '/second', behavior: {} },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0]).toEqual(
-      expect.objectContaining({
-        name: 'First Request Rule',
-        order: 2,
-      }),
-    );
-    expect(result.rules[1]).toEqual(
-      expect.objectContaining({
-        name: 'Second Request Rule',
-        order: 3,
-      }),
-    );
-    expect(result.rules[2]).toEqual(
-      expect.objectContaining({
-        name: 'First Response Rule',
-        order: 2,
-      }),
-    );
-    expect(result.rules[3]).toEqual(
-      expect.objectContaining({
-        name: 'Second Response Rule',
-        order: 3,
-      }),
-    );
-  });
-
-  it('should maintain the order of behaviors as specified by the user', () => {
-    const azionConfig = {
-      origin: [
-        {
-          name: 'my origin storage',
-          type: 'object_storage',
-          bucket: 'mybucket',
-          prefix: 'myfolder',
+          ],
         },
-      ],
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/',
-            behavior: {
-              setHeaders: ['Authorization: Bearer abc123'],
-              deliver: true,
-              setOrigin: {
-                name: 'my origin storage',
-                type: 'object_storage',
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'bypass_cache_phase',
+            target: null,
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly handle redirect to 301', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRedirect301',
+              match: '/',
+              behavior: {
+                redirectTo301: 'https://example.com',
               },
             },
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual([
-      expect.objectContaining({
-        name: 'add_request_header',
-        target: 'Authorization: Bearer abc123',
-      }),
-      expect.objectContaining({
-        name: 'deliver',
-      }),
-      expect.objectContaining({
-        name: 'set_origin',
-        target: 'my origin storage',
-      }),
-    ]);
-  });
-  it('should throw an error when the origin settings are not defined', () => {
-    const azionConfigWithoutOrigin = {
-      rules: {
-        request: [
-          {
-            name: 'testRule',
-            match: '/api',
-            behavior: {
-              setOrigin: {
-                name: 'undefined origin',
-                type: 'object_storage',
-              },
-            },
-          },
-        ],
-      },
-    };
-
-    expect(() => jsToJson(azionConfigWithoutOrigin)).toThrow(
-      "Rule setOrigin name 'undefined origin' not found in the origin settings",
-    );
-  });
-  it('should handle legacy config without behavior field for request rules', () => {
-    const azionConfig = {
-      origin: [
-        {
-          name: 'legacy origin',
-          type: 'object_storage',
-          addresses: ['teste.com'],
+          ],
         },
-      ],
-      rules: {
-        request: [
-          {
-            name: 'legacyRule',
-            match: '/legacy',
-            setOrigin: {
-              name: 'legacy origin',
-              type: 'object_storage',
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'redirect_to_301',
+            target: 'https://example.com',
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly handle redirect to 302', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testRedirect302',
+              match: '/',
+              behavior: {
+                redirectTo302: 'https://example.com',
+              },
             },
-            setHeaders: ['Authorization: Bearer legacy'],
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'redirect_to_302',
+            target: 'https://example.com',
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly handle capture match groups', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'testCapture',
+              match: '/',
+              behavior: {
+                capture: {
+                  match: '^/user/(.*)',
+                  captured: 'userId',
+                  subject: 'uri',
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'capture_match_groups',
+            target: {
+              regex: '^/user/(.*)',
+              captured_array: 'userId',
+              // eslint-disable-next-line no-template-curly-in-string
+              subject: '${uri}',
+            },
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly handle filterCookie behavior', () => {
+      const azionConfig = {
+        rules: {
+          response: [
+            {
+              name: 'testFilterCookie',
+              match: '/',
+              behavior: {
+                filterCookie: '_cookie',
+              },
+            },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'filter_response_cookie',
+            target: '_cookie',
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly process rules in the response phase', () => {
+      const azionConfig = {
+        rules: {
+          response: [
+            {
+              name: 'testResponsePhase',
+              match: '/',
+              behavior: {
+                setHeaders: ['X-Test-Header: value'],
+              },
+            },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'add_response_header',
+            target: 'X-Test-Header: value',
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly add multiple response headers', () => {
+      const azionConfig = {
+        rules: {
+          response: [
+            {
+              name: 'testMultipleHeaders',
+              match: '/',
+              behavior: {
+                setHeaders: [
+                  'X-Frame-Options: DENY',
+                  "Content-Security-Policy: default-src 'self'",
+                ],
+              },
+            },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'add_response_header',
+            target: 'X-Frame-Options: DENY',
+          }),
+          expect.objectContaining({
+            name: 'add_response_header',
+            target: "Content-Security-Policy: default-src 'self'",
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly handle enableGZIP behavior', () => {
+      const azionConfig = {
+        rules: {
+          response: [
+            {
+              name: 'testEnableGZIP',
+              match: '/',
+              behavior: {
+                enableGZIP: true,
+              },
+            },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'enable_gzip',
+            target: '',
+          }),
+        ]),
+      );
+    });
+
+    it('should handle rules with description and active properties correctly', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            {
+              name: 'Example Rule',
+              match: '/',
+              description: 'This rule redirects all traffic.',
+              active: false,
+            },
+            {
+              name: 'Second Rule',
+              match: '/api',
+              behavior: {},
+              // description is not provided here
+              active: true,
+            },
+            {
+              name: 'Third Rule',
+              match: '/home',
+              description: 'This rule handles home traffic.',
+              behavior: {},
+              // active is not provided here
+            },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules).toEqual([
+        expect.objectContaining({
+          name: 'Example Rule',
+          description: 'This rule redirects all traffic.',
+          is_active: false,
+        }),
+        expect.objectContaining({
+          name: 'Second Rule',
+          description: '', // Should default to an empty string
+          is_active: true,
+        }),
+        expect.objectContaining({
+          name: 'Third Rule',
+          description: 'This rule handles home traffic.',
+          is_active: true, // Should default to true
+        }),
+      ]);
+    });
+
+    it('should correctly assign order starting from 2 for request and response rules', () => {
+      const azionConfig = {
+        rules: {
+          request: [
+            { name: 'First Request Rule', match: '/', behavior: {} },
+            { name: 'Second Request Rule', match: '/second', behavior: {} },
+          ],
+          response: [
+            { name: 'First Response Rule', match: '/', behavior: {} },
+            { name: 'Second Response Rule', match: '/second', behavior: {} },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0]).toEqual(
+        expect.objectContaining({
+          name: 'First Request Rule',
+          order: 2,
+        }),
+      );
+      expect(result.rules[1]).toEqual(
+        expect.objectContaining({
+          name: 'Second Request Rule',
+          order: 3,
+        }),
+      );
+      expect(result.rules[2]).toEqual(
+        expect.objectContaining({
+          name: 'First Response Rule',
+          order: 2,
+        }),
+      );
+      expect(result.rules[3]).toEqual(
+        expect.objectContaining({
+          name: 'Second Response Rule',
+          order: 3,
+        }),
+      );
+    });
+
+    it('should maintain the order of behaviors as specified by the user', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my origin storage',
+            type: 'object_storage',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
           },
         ],
-      },
-    };
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/',
+              behavior: {
+                setHeaders: ['Authorization: Bearer abc123'],
+                deliver: true,
+                setOrigin: {
+                  name: 'my origin storage',
+                  type: 'object_storage',
+                },
+              },
+            },
+          ],
+        },
+      };
 
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'set_origin',
-          target: 'legacy origin',
-        }),
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual([
         expect.objectContaining({
           name: 'add_request_header',
-          target: 'Authorization: Bearer legacy',
-        }),
-      ]),
-    );
-  });
-
-  it('should handle legacy config without behavior field for response rules', () => {
-    const azionConfig = {
-      rules: {
-        response: [
-          {
-            name: 'legacyResponseRule',
-            match: '/legacy-response',
-            setHeaders: ['X-Legacy-Header: legacy'],
-            enableGZIP: true,
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'add_response_header',
-          target: 'X-Legacy-Header: legacy',
+          target: 'Authorization: Bearer abc123',
         }),
         expect.objectContaining({
-          name: 'enable_gzip',
-          target: '',
+          name: 'deliver',
         }),
-      ]),
-    );
-  });
-
-  it('should handle mixed legacy and new config for request rules', () => {
-    const azionConfig = {
-      origin: [
-        {
-          name: 'mixed origin',
-          type: 'object_storage',
-          addresses: ['teste.com'],
-        },
-      ],
-      rules: {
-        request: [
-          {
-            name: 'mixedRule',
-            match: '/mixed',
-            setOrigin: {
-              name: 'mixed origin',
-              type: 'object_storage',
-            },
-            behavior: {
-              setHeaders: ['Authorization: Bearer mixed'],
-            },
-          },
-        ],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
         expect.objectContaining({
           name: 'set_origin',
-          target: 'mixed origin',
+          target: 'my origin storage',
         }),
-        expect.objectContaining({
-          name: 'add_request_header',
-          target: 'Authorization: Bearer mixed',
-        }),
-      ]),
-    );
-  });
+      ]);
+    });
+    it('should throw an error when the origin settings are not defined', () => {
+      const azionConfigWithoutOrigin = {
+        rules: {
+          request: [
+            {
+              name: 'testRule',
+              match: '/api',
+              behavior: {
+                setOrigin: {
+                  name: 'undefined origin',
+                  type: 'object_storage',
+                },
+              },
+            },
+          ],
+        },
+      };
 
-  it('should handle mixed legacy and new config for response rules', () => {
-    const azionConfig = {
-      rules: {
-        response: [
+      expect(() => jsToJson(azionConfigWithoutOrigin)).toThrow(
+        "Rule setOrigin name 'undefined origin' not found in the origin settings",
+      );
+    });
+    it('should handle legacy config without behavior field for request rules', () => {
+      const azionConfig = {
+        origin: [
           {
-            name: 'mixedResponseRule',
-            match: '/mixed-response',
-            setHeaders: ['X-Mixed-Header: mixed'],
-            behavior: {
+            name: 'legacy origin',
+            type: 'object_storage',
+            addresses: ['teste.com'],
+          },
+        ],
+        rules: {
+          request: [
+            {
+              name: 'legacyRule',
+              match: '/legacy',
+              setOrigin: {
+                name: 'legacy origin',
+                type: 'object_storage',
+              },
+              setHeaders: ['Authorization: Bearer legacy'],
+            },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'set_origin',
+            target: 'legacy origin',
+          }),
+          expect.objectContaining({
+            name: 'add_request_header',
+            target: 'Authorization: Bearer legacy',
+          }),
+        ]),
+      );
+    });
+
+    it('should handle legacy config without behavior field for response rules', () => {
+      const azionConfig = {
+        rules: {
+          response: [
+            {
+              name: 'legacyResponseRule',
+              match: '/legacy-response',
+              setHeaders: ['X-Legacy-Header: legacy'],
               enableGZIP: true,
+            },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'add_response_header',
+            target: 'X-Legacy-Header: legacy',
+          }),
+          expect.objectContaining({
+            name: 'enable_gzip',
+            target: '',
+          }),
+        ]),
+      );
+    });
+
+    it('should handle mixed legacy and new config for request rules', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'mixed origin',
+            type: 'object_storage',
+            addresses: ['teste.com'],
+          },
+        ],
+        rules: {
+          request: [
+            {
+              name: 'mixedRule',
+              match: '/mixed',
+              setOrigin: {
+                name: 'mixed origin',
+                type: 'object_storage',
+              },
+              behavior: {
+                setHeaders: ['Authorization: Bearer mixed'],
+              },
+            },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'set_origin',
+            target: 'mixed origin',
+          }),
+          expect.objectContaining({
+            name: 'add_request_header',
+            target: 'Authorization: Bearer mixed',
+          }),
+        ]),
+      );
+    });
+
+    it('should handle mixed legacy and new config for response rules', () => {
+      const azionConfig = {
+        rules: {
+          response: [
+            {
+              name: 'mixedResponseRule',
+              match: '/mixed-response',
+              setHeaders: ['X-Mixed-Header: mixed'],
+              behavior: {
+                enableGZIP: true,
+              },
+            },
+          ],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.rules[0].behaviors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'add_response_header',
+            target: 'X-Mixed-Header: mixed',
+          }),
+          expect.objectContaining({
+            name: 'enable_gzip',
+            target: '',
+          }),
+        ]),
+      );
+    });
+    it('should correctly process cacheByQueryString with option "ignore"', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            cacheByQueryString: {
+              option: 'ignore',
             },
           },
         ],
-      },
-    };
+        rules: {
+          request: [],
+        },
+      };
 
-    const result = jsToJson(azionConfig);
-    expect(result.rules[0].behaviors).toEqual(
-      expect.arrayContaining([
+      const result = jsToJson(azionConfig);
+      expect(result.cache[0]).toEqual(
         expect.objectContaining({
-          name: 'add_response_header',
-          target: 'X-Mixed-Header: mixed',
+          cache_by_query_string: 'ignore',
+          query_string_fields: [],
         }),
+      );
+    });
+
+    it('should correctly process cacheByQueryString with option "whitelist" and list', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            cacheByQueryString: {
+              option: 'whitelist',
+              list: ['param1', 'param2'],
+            },
+          },
+        ],
+        rules: {
+          request: [],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.cache[0]).toEqual(
         expect.objectContaining({
-          name: 'enable_gzip',
-          target: '',
+          cache_by_query_string: 'whitelist',
+          query_string_fields: ['param1', 'param2'],
         }),
-      ]),
-    );
-  });
-  it('should correctly process cacheByQueryString with option "ignore"', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          cacheByQueryString: {
-            option: 'ignore',
+      );
+    });
+
+    it('should throw an error if cacheByQueryString option is "whitelist" or "blacklist" without list', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            cacheByQueryString: {
+              option: 'whitelist',
+            },
           },
+        ],
+        rules: {
+          request: [],
         },
-      ],
-      rules: {
-        request: [],
-      },
-    };
+      };
 
-    const result = jsToJson(azionConfig);
-    expect(result.cache[0]).toEqual(
-      expect.objectContaining({
-        cache_by_query_string: 'ignore',
-        query_string_fields: [],
-      }),
-    );
-  });
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'list' field is required when 'option' is 'whitelist' or 'blacklist'.",
+      );
+    });
 
-  it('should correctly process cacheByQueryString with option "whitelist" and list', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          cacheByQueryString: {
-            option: 'whitelist',
-            list: ['param1', 'param2'],
+    it('should correctly process cacheByQueryString with option "blacklist" and list', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            cacheByQueryString: {
+              option: 'blacklist',
+              list: ['param1', 'param2'],
+            },
           },
+        ],
+        rules: {
+          request: [],
         },
-      ],
-      rules: {
-        request: [],
-      },
-    };
+      };
 
-    const result = jsToJson(azionConfig);
-    expect(result.cache[0]).toEqual(
-      expect.objectContaining({
-        cache_by_query_string: 'whitelist',
-        query_string_fields: ['param1', 'param2'],
-      }),
-    );
-  });
+      const result = jsToJson(azionConfig);
+      expect(result.cache[0]).toEqual(
+        expect.objectContaining({
+          cache_by_query_string: 'blacklist',
+          query_string_fields: ['param1', 'param2'],
+        }),
+      );
+    });
 
-  it('should throw an error if cacheByQueryString option is "whitelist" or "blacklist" without list', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          cacheByQueryString: {
-            option: 'whitelist',
+    it('should correctly process cacheByQueryString with option "all"', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            cacheByQueryString: {
+              option: 'varies',
+            },
           },
+        ],
+        rules: {
+          request: [],
         },
-      ],
-      rules: {
-        request: [],
-      },
-    };
+      };
 
-    expect(() => jsToJson(azionConfig)).toThrow(
-      "The 'list' field is required when 'option' is 'whitelist' or 'blacklist'.",
-    );
-  });
-
-  it('should correctly process cacheByQueryString with option "blacklist" and list', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          cacheByQueryString: {
-            option: 'blacklist',
-            list: ['param1', 'param2'],
+      const result = jsToJson(azionConfig);
+      expect(result.cache[0]).toEqual(
+        expect.objectContaining({
+          cache_by_query_string: 'all',
+          query_string_fields: [],
+        }),
+      );
+    });
+    it('should correctly process cacheByCookie with option "ignore"', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            cacheByCookie: {
+              option: 'ignore',
+            },
           },
+        ],
+        rules: {
+          request: [],
         },
-      ],
-      rules: {
-        request: [],
-      },
-    };
+      };
 
-    const result = jsToJson(azionConfig);
-    expect(result.cache[0]).toEqual(
-      expect.objectContaining({
-        cache_by_query_string: 'blacklist',
-        query_string_fields: ['param1', 'param2'],
-      }),
-    );
-  });
+      const result = jsToJson(azionConfig);
+      expect(result.cache[0]).toEqual(
+        expect.objectContaining({
+          cache_by_cookie: 'ignore',
+          cookie_names: [],
+        }),
+      );
+    });
 
-  it('should correctly process cacheByQueryString with option "all"', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          cacheByQueryString: {
-            option: 'varies',
+    it('should correctly process cacheByCookie with option "whitelist" and list', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            cacheByCookie: {
+              option: 'whitelist',
+              list: ['cookie1', 'cookie2'],
+            },
           },
+        ],
+        rules: {
+          request: [],
         },
-      ],
-      rules: {
-        request: [],
-      },
-    };
+      };
 
-    const result = jsToJson(azionConfig);
-    expect(result.cache[0]).toEqual(
-      expect.objectContaining({
-        cache_by_query_string: 'all',
-        query_string_fields: [],
-      }),
-    );
-  });
-  it('should correctly process cacheByCookie with option "ignore"', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          cacheByCookie: {
-            option: 'ignore',
+      const result = jsToJson(azionConfig);
+      expect(result.cache[0]).toEqual(
+        expect.objectContaining({
+          cache_by_cookie: 'whitelist',
+          cookie_names: ['cookie1', 'cookie2'],
+        }),
+      );
+    });
+
+    it('should throw an error if cacheByCookie option is "whitelist" or "blacklist" without list', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            cacheByCookie: {
+              option: 'whitelist',
+            },
           },
+        ],
+        rules: {
+          request: [],
         },
-      ],
-      rules: {
-        request: [],
-      },
-    };
+      };
 
-    const result = jsToJson(azionConfig);
-    expect(result.cache[0]).toEqual(
-      expect.objectContaining({
-        cache_by_cookie: 'ignore',
-        cookie_names: [],
-      }),
-    );
-  });
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'list' field is required when 'option' is 'whitelist' or 'blacklist'.",
+      );
+    });
 
-  it('should correctly process cacheByCookie with option "whitelist" and list', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          cacheByCookie: {
-            option: 'whitelist',
-            list: ['cookie1', 'cookie2'],
+    it('should correctly process cacheByCookie with option "blacklist" and list', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            cacheByCookie: {
+              option: 'blacklist',
+              list: ['cookie1', 'cookie2'],
+            },
           },
+        ],
+        rules: {
+          request: [],
         },
-      ],
-      rules: {
-        request: [],
-      },
-    };
+      };
 
-    const result = jsToJson(azionConfig);
-    expect(result.cache[0]).toEqual(
-      expect.objectContaining({
-        cache_by_cookie: 'whitelist',
-        cookie_names: ['cookie1', 'cookie2'],
-      }),
-    );
-  });
+      const result = jsToJson(azionConfig);
+      expect(result.cache[0]).toEqual(
+        expect.objectContaining({
+          cache_by_cookie: 'blacklist',
+          cookie_names: ['cookie1', 'cookie2'],
+        }),
+      );
+    });
 
-  it('should throw an error if cacheByCookie option is "whitelist" or "blacklist" without list', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          cacheByCookie: {
-            option: 'whitelist',
+    it('should correctly process cacheByCookie with option "all"', () => {
+      const azionConfig = {
+        cache: [
+          {
+            name: 'testCache',
+            cacheByCookie: {
+              option: 'varies',
+            },
           },
+        ],
+        rules: {
+          request: [],
         },
-      ],
-      rules: {
-        request: [],
-      },
-    };
+      };
 
-    expect(() => jsToJson(azionConfig)).toThrow(
-      "The 'list' field is required when 'option' is 'whitelist' or 'blacklist'.",
-    );
-  });
-
-  it('should correctly process cacheByCookie with option "blacklist" and list', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          cacheByCookie: {
-            option: 'blacklist',
-            list: ['cookie1', 'cookie2'],
-          },
-        },
-      ],
-      rules: {
-        request: [],
-      },
-    };
-
-    const result = jsToJson(azionConfig);
-    expect(result.cache[0]).toEqual(
-      expect.objectContaining({
-        cache_by_cookie: 'blacklist',
-        cookie_names: ['cookie1', 'cookie2'],
-      }),
-    );
+      const result = jsToJson(azionConfig);
+      expect(result.cache[0]).toEqual(
+        expect.objectContaining({
+          cache_by_cookie: 'all',
+          cookie_names: [],
+        }),
+      );
+    });
   });
 
-  it('should correctly process cacheByCookie with option "all"', () => {
-    const azionConfig = {
-      cache: [
-        {
-          name: 'testCache',
-          cacheByCookie: {
-            option: 'varies',
+  describe('jsToJson - Domain', () => {
+    it('should throw process the manifest config when the domain name is not provided', () => {
+      const azionConfig = {
+        domain: {
+          cnames: ['www.example.com'],
+        },
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'name' field is required in the domain object.",
+      );
+    });
+
+    it('should correctly process the manifest config when the domain cnameAccessOnly undefined', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          cnames: ['www.example.com'],
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          cname_access_only: false,
+          cnames: ['www.example.com'],
+        }),
+      );
+    });
+
+    it('should correctly process the manifest config when the domain cnameAccessOnly is true', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          cnames: ['www.example.com'],
+          cnameAccessOnly: true,
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          cname_access_only: true,
+          cnames: ['www.example.com'],
+        }),
+      );
+    });
+
+    it('should throw process the manifest config when the domain cnames is not an array', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          cnames: 'www.example.com',
+        },
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'cnames' field must be an array of strings.",
+      );
+    });
+
+    it('should throw process the manifest config when the domain digitalCertificateId different from lets_encrypt', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          digitalCertificateId: 'mycert',
+        },
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        'Domain mydomain has an invalid digital certificate ID: mycert',
+      );
+    });
+
+    it('should correctly process the manifest config when the domain digitalCertificateId is lets_encrypt', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          digitalCertificateId: 'lets_encrypt',
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          digital_certificate_id: 'lets_encrypt',
+        }),
+      );
+    });
+
+    it('should correctly process the manifest config when the domain digitalCertificateId is not provided', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          digital_certificate_id: null,
+        }),
+      );
+    });
+
+    it('should correctly process the manifest config when the domain mtls is not provided', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+        },
+      };
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          is_mtls_enabled: false,
+        }),
+      );
+    });
+
+    it('should correctly process the manifest config when the domain mtls is active and verification equal enforce', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          mtls: {
+            verification: 'enforce',
+            trustedCaCertificateId: 12345,
           },
         },
-      ],
-      rules: {
-        request: [],
-      },
-    };
+      };
 
-    const result = jsToJson(azionConfig);
-    expect(result.cache[0]).toEqual(
-      expect.objectContaining({
-        cache_by_cookie: 'all',
-        cookie_names: [],
-      }),
-    );
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          is_mtls_enabled: true,
+          mtls_verification: 'enforce',
+          mtls_trusted_ca_certificate_id: 12345,
+        }),
+      );
+    });
+
+    it('should correctly process the manifest config when the domain mtls is active and verification equal permissive', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          mtls: {
+            verification: 'permissive',
+            trustedCaCertificateId: 12345,
+          },
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          is_mtls_enabled: true,
+          mtls_verification: 'permissive',
+          mtls_trusted_ca_certificate_id: 12345,
+        }),
+      );
+    });
+
+    it('should throw an error when the domain verification is not provided', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          mtls: {
+            trustedCaCertificateId: 12345,
+          },
+        },
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'verification and trustedCaCertificateId' fields are required in the mtls object.",
+      );
+    });
+
+    it('should throw an error when the domain trustedCaCertificateId is not provided', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          mtls: {
+            verification: 'enforce',
+          },
+        },
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'verification and trustedCaCertificateId' fields are required in the mtls object.",
+      );
+    });
+
+    it('should correctly process the manifest config when the domain mtls and crlList is present', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          mtls: {
+            verification: 'enforce',
+            trustedCaCertificateId: 12345,
+            crlList: [123, 456],
+          },
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          is_mtls_enabled: true,
+          mtls_verification: 'enforce',
+          mtls_trusted_ca_certificate_id: 12345,
+          crl_list: [123, 456],
+        }),
+      );
+    });
+
+    it('should correctly process the manifest config when the domain edgeApplicationId is provided', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          edgeApplicationId: 12345,
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          edge_application_id: 12345,
+        }),
+      );
+    });
+
+    it('should throw an error when the domain edgeApplicationId is not a number', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          edgeApplicationId: '12345',
+        },
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'edgeApplicationId' field must be a number.",
+      );
+    });
+
+    it('should correctly process the manifest config when the domain edgeApplicationId is not provided', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          edge_application_id: null,
+        }),
+      );
+    });
+
+    it('should correctly process the manifest config when the domain edgeFirewallId is provided', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          edgeFirewallId: 12345,
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          edge_firewall_id: 12345,
+        }),
+      );
+    });
+
+    it('should throw an error when the domain edgeFirewallId is not a number', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          edgeFirewallId: '12345',
+        },
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'edgeFirewallId' field must be a number.",
+      );
+    });
+
+    it('should correctly process the manifest config when the domain edgeFirewallId is not provided', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          edge_firewall_id: null,
+        }),
+      );
+    });
   });
 });

--- a/lib/utils/generateManifest/helpers/azion.config.example.js
+++ b/lib/utils/generateManifest/helpers/azion.config.example.js
@@ -1,4 +1,17 @@
 export default {
+  domain: {
+    name: 'my_domain',
+    cnameAccessOnly: false, // Optional, defaults to false
+    cnames: ['www.example.com'], // Optional
+    edgeApplicationId: 12345, // Optional
+    edgeFirewallId: 12345, // Optional
+    digitalCertificateId: 'lets_encrypt', // 'lets_encrypt' or null
+    mtls: {
+      verification: 'enforce', // 'enforce' or 'permissive'
+      trustedCaCertificateId: 12345,
+      crlList: [111, 222],
+    }, // Optional
+  },
   origin: [
     {
       name: 'myneworigin',

--- a/lib/utils/generateManifest/helpers/schema.js
+++ b/lib/utils/generateManifest/helpers/schema.js
@@ -629,6 +629,81 @@ const azionConfigSchema = {
         },
       },
     },
+    domain: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          errorMessage: "The 'name' field must be a string.",
+        },
+        cnameAccessOnly: {
+          type: 'boolean',
+          errorMessage: "The 'cnameAccessOnly' field must be a boolean.",
+        },
+        cnames: {
+          type: 'array',
+          items: {
+            type: 'string',
+            errorMessage: "Each item in 'cnames' must be a string.",
+          },
+          errorMessage: {
+            type: "The 'cnames' field must be an array of strings.",
+          },
+        },
+        edgeApplicationId: {
+          type: 'number',
+          errorMessage: "The 'edgeApplicationId' field must be a number.",
+        },
+        edgeFirewallId: {
+          type: 'number',
+          errorMessage: "The 'edgeFirewallId' field must be a number.",
+        },
+        digitalCertificateId: {
+          type: 'string',
+          errorMessage: "The 'digitalCertificateId' field must be a string.",
+        },
+        mtls: {
+          type: 'object',
+          properties: {
+            verification: {
+              type: 'string',
+              errorMessage: "The 'verification' field must be a string.",
+            },
+            trustedCaCertificateId: {
+              type: 'number',
+              errorMessage:
+                "The 'trustedCaCertificateId' field must be a number.",
+            },
+            crlList: {
+              type: 'array',
+              items: {
+                type: 'number',
+                errorMessage: "Each item in 'crlList' must be a number.",
+              },
+              errorMessage: {
+                type: "The 'crlList' field must be an array of numbers.",
+              },
+            },
+          },
+          required: ['verification', 'trustedCaCertificateId'],
+          additionalProperties: false,
+          errorMessage: {
+            additionalProperties:
+              'No additional properties are allowed in the mtls object.',
+            required:
+              "The 'verification and trustedCaCertificateId' fields are required in the mtls object.",
+          },
+        },
+      },
+      required: ['name'],
+      additionalProperties: false,
+      errorMessage: {
+        type: "The 'domain' field must be an object.",
+        additionalProperties:
+          'No additional properties are allowed in the domain object.',
+        required: "The 'name' field is required in the domain object.",
+      },
+    },
   },
   required: [],
   additionalProperties: false,

--- a/lib/utils/generateManifest/strategy/implementations/cacheManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/cacheManifestStrategy.js
@@ -1,0 +1,90 @@
+import ManifestStrategy from '../manifestStrategy.js';
+
+/**
+ * CacheManifestStrategy
+ * @class CacheManifestStrategy
+ * @description This class is implementation of the Cache Manifest Strategy.
+ */
+class CacheManifestStrategy extends ManifestStrategy {
+  /**
+   * Generates the cache manifest based on the configuration.
+   * @param {object} config - The configuration object.
+   * @param {object} context - The context object.
+   * @returns {object} The generated cache manifest.
+   * @throws {Error} When the expression is not purely mathematical.
+   */
+  // eslint-disable-next-line no-unused-vars, class-methods-use-this
+  generate(config, context) {
+    // Helper function to safely evaluate mathematical expressions
+    const evaluateMathExpression = (expression) => {
+      if (typeof expression === 'number') {
+        return expression;
+      }
+      if (/^[0-9+\-*/.() ]+$/.test(expression)) {
+        // eslint-disable-next-line no-eval
+        return eval(expression);
+      }
+      throw new Error(`Expression is not purely mathematical: ${expression}`);
+    };
+
+    const payload = [];
+    if (!Array.isArray(config?.cache) || config?.cache.length === 0) {
+      return payload;
+    }
+    config?.cache.forEach((cache) => {
+      const maxAgeSecondsBrowser = cache?.browser
+        ? evaluateMathExpression(cache.browser.maxAgeSeconds)
+        : 0;
+      const maxAgeSecondsEdge = cache?.edge
+        ? evaluateMathExpression(cache.edge.maxAgeSeconds)
+        : 60;
+
+      const cacheSetting = {
+        name: cache.name,
+        browser_cache_settings: cache?.browser ? 'override' : 'honor',
+        browser_cache_settings_maximum_ttl: maxAgeSecondsBrowser,
+        cdn_cache_settings: cache?.edge ? 'override' : 'honor',
+        cdn_cache_settings_maximum_ttl: maxAgeSecondsEdge,
+        enable_caching_for_post: cache?.methods?.post || false,
+        enable_caching_for_options: cache?.methods?.options || false,
+        enable_query_string_sort: cache?.queryStringSort || false,
+      };
+
+      if (cache.cacheByQueryString) {
+        cacheSetting.cache_by_query_string =
+          cache.cacheByQueryString.option === 'varies'
+            ? 'all'
+            : cache.cacheByQueryString.option;
+        if (
+          cache.cacheByQueryString.option === 'whitelist' ||
+          cache.cacheByQueryString.option === 'blacklist'
+        ) {
+          cacheSetting.query_string_fields =
+            cache.cacheByQueryString.list || [];
+        } else {
+          cacheSetting.query_string_fields = [];
+        }
+      }
+
+      if (cache.cacheByCookie) {
+        cacheSetting.cache_by_cookie =
+          cache.cacheByCookie.option === 'varies'
+            ? 'all'
+            : cache.cacheByCookie.option;
+        if (
+          cache.cacheByCookie.option === 'whitelist' ||
+          cache.cacheByCookie.option === 'blacklist'
+        ) {
+          cacheSetting.cookie_names = cache.cacheByCookie.list || [];
+        } else {
+          cacheSetting.cookie_names = [];
+        }
+      }
+
+      payload.push(cacheSetting);
+    });
+    return payload;
+  }
+}
+
+export default CacheManifestStrategy;

--- a/lib/utils/generateManifest/strategy/implementations/domainManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/domainManifestStrategy.js
@@ -1,0 +1,63 @@
+import ManifestStrategy from '../manifestStrategy.js';
+
+/**
+ * DomainManisfestStrategy
+ * @class DomainManisfestStrategy
+ * @description This class is implementation of the Domain Manifest Strategy.
+ */
+class DomainManisfestStrategy extends ManifestStrategy {
+  /**
+   * Generates the domain manifest based on the configuration.
+   * @param {object} config - The configuration object.
+   * @param {object} context - The context object.
+   * @returns {object} The generated domain manifest.
+   * @throws {Error} When the domain has an invalid digital certificate ID.
+   */
+  // eslint-disable-next-line no-unused-vars, class-methods-use-this
+  generate(config, context) {
+    const domain = config?.domain;
+    if (!domain) {
+      return {};
+    }
+    if (
+      domain.digitalCertificateId &&
+      domain.digitalCertificateId !== 'lets_encrypt'
+    ) {
+      throw new Error(
+        `Domain ${domain.name} has an invalid digital certificate ID: ${domain.digitalCertificateId}. Only 'lets_encrypt' or null is supported.`,
+      );
+    }
+
+    if (
+      domain.mtls?.verification &&
+      domain.mtls.verification !== 'enforce' &&
+      domain.mtls.verification !== 'permissive'
+    ) {
+      throw new Error(
+        `Domain ${domain.name} has an invalid verification value: ${domain.mtls.verification}. Only 'enforce' or 'permissive' is supported.`,
+      );
+    }
+
+    const domainSetting = {
+      name: domain.name,
+      cname_access_only: domain.cnameAccessOnly || false,
+      cnames: domain.cnames || [],
+      digital_certificate_id: domain.digitalCertificateId || null,
+      edge_application_id: domain.edgeApplicationId || null,
+      edge_firewall_id: domain.edgeFirewallId || null,
+      active: true,
+    };
+    if (domain.mtls) {
+      domainSetting.is_mtls_enabled = true;
+      domainSetting.mtls_verification = domain.mtls.verification;
+      domainSetting.mtls_trusted_ca_certificate_id =
+        domain.mtls.trustedCaCertificateId;
+      domainSetting.crl_list = domain.mtls.crlList || [];
+    } else {
+      domainSetting.is_mtls_enabled = false;
+    }
+    return domainSetting;
+  }
+}
+
+export default DomainManisfestStrategy;

--- a/lib/utils/generateManifest/strategy/implementations/originManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/originManifestStrategy.js
@@ -1,0 +1,49 @@
+import ManifestStrategy from '../manifestStrategy.js';
+
+/**
+ * OriginManifestStrategy
+ * @class OriginManifestStrategy
+ * @description This class is implementation of the Origin Manifest Strategy.
+ */
+class OriginManifestStrategy extends ManifestStrategy {
+  /**
+   * Generates the origin manifest based on the configuration.
+   * @param {object} config - The configuration object.
+   * @param {object} context - The context object.
+   * @returns {object} The generated origin manifest.
+   * @throws {Error} When the origin type is not supported.
+   */
+  // eslint-disable-next-line no-unused-vars, class-methods-use-this
+  generate(config, context) {
+    const payload = [];
+    if (!Array.isArray(config?.origin) || config?.origin.length === 0) {
+      return payload;
+    }
+    config?.origin.forEach((origin) => {
+      if (origin.type !== 'object_storage' && origin.type !== 'single_origin') {
+        throw new Error(
+          `Rule setOrigin originType '${origin.type}' is not supported`,
+        );
+      }
+      const originSetting = {
+        name: origin.name,
+        origin_type: origin.type,
+      };
+
+      if (origin.type === 'object_storage') {
+        originSetting.bucket = origin.bucket;
+        originSetting.prefix = origin.prefix;
+      }
+      if (origin.type === 'single_origin') {
+        originSetting.addresses = origin.addresses?.map((address) => {
+          return { address };
+        });
+        originSetting.host_header = origin.hostHeader;
+      }
+      payload.push(originSetting);
+    });
+    return payload;
+  }
+}
+
+export default OriginManifestStrategy;

--- a/lib/utils/generateManifest/strategy/implementations/rulesManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/rulesManifestStrategy.js
@@ -1,0 +1,106 @@
+import ManifestStrategy from '../manifestStrategy.js';
+import {
+  requestBehaviors,
+  responseBehaviors,
+} from '../../helpers/behaviors.js';
+
+/**
+ * RulesManifestStrategy
+ * @class RulesManifestStrategy
+ * @description This class is implementation of the Rules Manifest Strategy.
+ */
+class RulesManifestStrategy extends ManifestStrategy {
+  /**
+   * Adds behaviors to the CDN rule.
+   * @param {object} cdnRule - The CDN rule.
+   * @param {object} behaviors - The behaviors.
+   * @param {object} behaviorDefinitions - The behavior definitions.
+   * @param {object} payloadContext - The payload context.
+   * @returns {void}
+   */
+  // eslint-disable-next-line class-methods-use-this
+  #addBehaviors(cdnRule, behaviors, behaviorDefinitions, payloadContext) {
+    if (behaviors && typeof behaviors === 'object') {
+      Object.entries(behaviors).forEach(([key, value]) => {
+        if (behaviorDefinitions[key]) {
+          const transformedBehavior = behaviorDefinitions[key].transform(
+            value,
+            payloadContext,
+          );
+          if (Array.isArray(transformedBehavior)) {
+            cdnRule.behaviors.push(...transformedBehavior);
+          } else if (transformedBehavior) {
+            cdnRule.behaviors.push(transformedBehavior);
+          }
+        } else {
+          console.warn(`Unknown behavior: ${key}`);
+        }
+      });
+    }
+  }
+
+  /**
+   * Generates the rules manifest based on the configuration.
+   * @param {object} config - The configuration object.
+   * @param {object} context - The context object.
+   * @returns {object} The generated rules manifest.
+   */
+  generate(config, context) {
+    const payload = [];
+    // request
+    if (Array.isArray(config?.rules?.request)) {
+      config?.rules?.request?.forEach((rule, index) => {
+        const cdnRule = {
+          name: rule.name,
+          phase: 'request',
+          description: rule.description ?? '',
+          is_active: rule.active !== undefined ? rule.active : true, // Default to true if not provided
+          order: index + 2, // index starts at 2, because the default rule is index 1
+          criteria: [
+            [
+              {
+                variable: `\${${rule.variable ?? 'uri'}}`,
+                operator: 'matches',
+                conditional: 'if',
+                input_value: rule.match,
+              },
+            ],
+          ],
+          behaviors: [],
+        };
+        this.#addBehaviors(cdnRule, rule.behavior, requestBehaviors, context);
+        payload.push(cdnRule);
+      });
+    }
+
+    // response
+    if (Array.isArray(config?.rules?.response)) {
+      config?.rules?.response.forEach((rule, index) => {
+        const cdnRule = {
+          name: rule.name,
+          phase: 'response',
+          description: rule.description ?? '',
+          is_active: rule.active !== undefined ? rule.active : true, // Default to true if not provided
+          order: index + 2, // index starts at 2, because the default rule is index 1
+          criteria: [
+            [
+              {
+                variable: `\${${rule.variable ?? 'uri'}}`,
+                operator: 'matches',
+                conditional: 'if',
+                input_value: rule.match,
+              },
+            ],
+          ],
+          behaviors: [],
+        };
+        this.#addBehaviors(cdnRule, rule.behavior, responseBehaviors, context);
+        payload.push(cdnRule);
+      });
+    }
+
+    return payload;
+  }
+}
+
+export default RulesManifestStrategy;

--- a/lib/utils/generateManifest/strategy/manifestContext.js
+++ b/lib/utils/generateManifest/strategy/manifestContext.js
@@ -1,0 +1,35 @@
+/**
+ * ManifestContext
+ * @class
+ * @description This class is responsible for generating the context of the manifest.
+ */
+class ManifestContext {
+  constructor() {
+    this.strategies = {};
+  }
+
+  /**
+   * Sets the strategy for a given type.
+   * @param {string} type - The type of the strategy.
+   * @param {object} strategy - The strategy
+   * @returns {void}
+   */
+  setStrategy(type, strategy) {
+    this.strategies[type] = strategy;
+  }
+
+  /**
+   * Generates the context of the manifest.
+   * @param {object} config - The configuration object.
+   * @param {object} context - The context object.
+   * @returns {object} The context object.
+   */
+  generate(config, context = {}) {
+    Object.keys(this.strategies).forEach((key) => {
+      context[key] = this.strategies[key].generate(config, context);
+    });
+    return context;
+  }
+}
+
+export default ManifestContext;

--- a/lib/utils/generateManifest/strategy/manifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/manifestStrategy.js
@@ -1,0 +1,20 @@
+/**
+ * ManifestStrategy
+ * @class ManifestStrategy
+ * @description This class is the base class for all manifest strategies.
+ */
+
+class ManifestStrategy {
+  /**
+   * Generates the manifest based on the configuration.
+   * @param {object} config - The configuration object.
+   * @param {object} context - The context object.
+   * @returns {*} The generated manifest.
+   */
+  // eslint-disable-next-line no-unused-vars, class-methods-use-this
+  generate(config, context) {
+    throw new Error('This method should be overridden!');
+  }
+}
+
+export default ManifestStrategy;


### PR DESCRIPTION
Adding support for domains in the manifest generation, including the Azion API parameters for creating one or more domains.
The output was added to the `.edge/manifest.json` file that will be consumed by the CLI.

**Example:**

The full example in `./lib/utils/generateManifest/helpers/azion.config.example.js`

```js
module.exports = {
  domain:  {
     name: 'my_domain',
     cnameAccessOnly: false, // Optional, defaults to false
     cnames: ['www.example.com'], // Optional
     edgeApplicationId: 12345, // Optional
     edgeFirewallId: 12345, // Optional
     digitalCertificateId: 'lets_encrypt', // 'lets_encrypt' or null
     mtls: {
       verification: 'enforce', // 'enforce' or 'permissive'
       trustedCaCertificateId: 12345,
       crlList: [111, 222],
      }, // Optional
   },
};
```

**Tests:**

```bash
yarn jest lib/utils/generateManifest/generateManifest.utils.test.js
```

### Bonus

A refactor was performed in `generateManifest.utils.js` with a design pattern (strategy) for better organization and maintenance of this feature.

