### PR TITLE
feat: added all origins parameters to the manifest

### DIFF
--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -554,7 +554,7 @@ describe('Utils - generateManifest', () => {
             protocolPolicy: 'preserve',
             hostHeader: '${host}',
             method: 'ip_hash',
-            redirectionEnabled: true,
+            redirection: true,
             connectionTimeout: 60,
             timeoutBetweenBytes: 120,
             hmac: {

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -576,7 +576,7 @@ describe('Utils - generateManifest', () => {
                 address: 'http.bin.org',
               },
             ],
-            originPath: '/',
+            origin_path: '/',
             method: 'ip_hash',
             origin_protocol_policy: 'preserve',
             host_header: '${host}',

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -554,11 +554,11 @@ describe('Utils - generateManifest', () => {
             protocolPolicy: 'preserve',
             hostHeader: '${host}',
             method: 'ip_hash',
-            isOriginRedirectionEnabled: true,
+            redirectionEnabled: true,
             connectionTimeout: 60,
             timeoutBetweenBytes: 120,
             hmac: {
-              regionName: 'us-east-1',
+              region: 'us-east-1',
               accessKey: 'myaccesskey',
               secretKey: 'secretKey',
             },

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -539,6 +539,185 @@ describe('Utils - generateManifest', () => {
   });
 
   describe('jsToJson - Origin', () => {
+    it('should process the manifest config when the origin is single_origin and all fields', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my single origin',
+            type: 'single_origin',
+            path: '/',
+            addresses: [
+              {
+                address: 'http.bin.org',
+              },
+            ],
+            protocolPolicy: 'preserve',
+            hostHeader: '${host}',
+            method: 'ip_hash',
+            isOriginRedirectionEnabled: true,
+            connectionTimeout: 60,
+            timeoutBetweenBytes: 120,
+            hmac: {
+              regionName: 'us-east-1',
+              accessKey: 'myaccesskey',
+              secretKey: 'secretKey',
+            },
+          },
+        ],
+      };
+      const result = jsToJson(azionConfig);
+      expect(result.origin).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'my single origin',
+            origin_type: 'single_origin',
+            addresses: [
+              {
+                address: 'http.bin.org',
+              },
+            ],
+            originPath: '/',
+            method: 'ip_hash',
+            origin_protocol_policy: 'preserve',
+            host_header: '${host}',
+            is_origin_redirection_enabled: true,
+            connection_timeout: 60,
+            timeout_between_bytes: 120,
+            hmac_authentication: true,
+            hmac_region_name: 'us-east-1',
+            hmac_access_key: 'myaccesskey',
+            hmac_secret_key: 'secretKey',
+          }),
+        ]),
+      );
+    });
+
+    it('should process the manifest config when the origin is provided id and key', () => {
+      const azionConfig = {
+        origin: [
+          {
+            id: 123456,
+            key: 'abcdef',
+            name: 'my single',
+            type: 'single_origin',
+            addresses: [
+              {
+                address: 'http.bin.org',
+              },
+            ],
+          },
+        ],
+      };
+      const result = jsToJson(azionConfig);
+      expect(result.origin).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 123456,
+            key: 'abcdef',
+            name: 'my single',
+            origin_type: 'single_origin',
+            addresses: [
+              {
+                address: 'http.bin.org',
+              },
+            ],
+          }),
+        ]),
+      );
+    });
+
+    it('should throw an error when the origin type single_origin is missing the addresses field', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my single',
+            type: 'single_origin',
+          },
+        ],
+      };
+      expect(() => jsToJson(azionConfig)).toThrow(
+        'When origin type is single_origin, addresses is required',
+      );
+    });
+
+    // should process the manifest config when the origin is single_origin and addresses is array of strings
+    it('should process the manifest config when the origin is single_origin and addresses is array of strings', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my single',
+            type: 'single_origin',
+            addresses: ['http.bin.org', 'http2.bin.org'],
+          },
+        ],
+      };
+      const result = jsToJson(azionConfig);
+      expect(result.origin).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'my single',
+            origin_type: 'single_origin',
+            addresses: [
+              {
+                address: 'http.bin.org',
+              },
+              {
+                address: 'http2.bin.org',
+              },
+            ],
+          }),
+        ]),
+      );
+    });
+
+    it('should throw an error when the origin type single_origin the addresses weight is invalid', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my single',
+            type: 'single_origin',
+            addresses: [
+              {
+                address: 'http.bin.org',
+                weight: 1,
+              },
+              {
+                address: 'http2.bin.org',
+                weight: 11,
+              },
+            ],
+          },
+        ],
+      };
+      expect(() => jsToJson(azionConfig)).toThrow(
+        'When origin type is single_origin, weight must be between 0 and 10',
+      );
+    });
+
+    it('should process the manifest config when the origin is object_storage and all fields', () => {
+      const azionConfig = {
+        origin: [
+          {
+            name: 'my origin storage',
+            type: 'object_storage',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
+          },
+        ],
+      };
+      const result = jsToJson(azionConfig);
+      expect(result.origin).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: 'my origin storage',
+            origin_type: 'object_storage',
+            bucket: 'mybucket',
+            prefix: 'myfolder',
+          }),
+        ]),
+      );
+    });
+
     it('should process the manifest config when the origin name and type are the same as the rules setOrigin name and type', () => {
       const azionConfig = {
         origin: [
@@ -664,7 +843,6 @@ describe('Utils - generateManifest', () => {
       );
     });
 
-    // should throw an error when the origin type is incorret
     it('should throw an error when the origin type is incorrect', () => {
       const azionConfig = {
         origin: [
@@ -692,7 +870,7 @@ describe('Utils - generateManifest', () => {
       };
 
       expect(() => jsToJson(azionConfig)).toThrow(
-        "Rule setOrigin originType 'name_incorrect' is not supported",
+        "The 'type' field must be a string and one of 'single_origin', 'object_storage', 'load_balancer' or 'live_ingest'.",
       );
     });
 
@@ -703,7 +881,11 @@ describe('Utils - generateManifest', () => {
             name: 'my single origin',
             type: 'single_origin',
             hostHeader: 'www.example.com',
-            addresses: ['test.com'],
+            addresses: [
+              {
+                address: 'http.bin.org',
+              },
+            ],
           },
         ],
         rules: {
@@ -730,7 +912,7 @@ describe('Utils - generateManifest', () => {
             origin_type: 'single_origin',
             addresses: [
               {
-                address: 'test.com',
+                address: 'http.bin.org',
               },
             ],
             host_header: 'www.example.com',
@@ -1133,7 +1315,6 @@ describe('Utils - generateManifest', () => {
           {
             name: 'legacy origin',
             type: 'object_storage',
-            addresses: ['teste.com'],
           },
         ],
         rules: {
@@ -1201,7 +1382,6 @@ describe('Utils - generateManifest', () => {
           {
             name: 'mixed origin',
             type: 'object_storage',
-            addresses: ['teste.com'],
           },
         ],
         rules: {

--- a/lib/utils/generateManifest/helpers/azion.config.example.js
+++ b/lib/utils/generateManifest/helpers/azion.config.example.js
@@ -31,9 +31,9 @@ export default {
       hostHeader: '${host}', // Defaults to '${host}' if not provided
       connectionTimeout: 60, // Optional. Default 60 if not provided
       timeoutBetweenBytes: 120, // Optional. Default 120 if not provided
-      isOriginRedirectionEnabled: false, // Optional. Default false if not provided
+      redirectionEnabled: false, // Optional. Default false if not provided
       hmac: {
-        regionName: 'us-east-1', // Required for hmac
+        region: 'us-east-1', // Required for hmac
         accessKey: 'myaccesskey', // Required for hmac
         secretKey: 'secretKey', // Required for hmac
       }, // Optional

--- a/lib/utils/generateManifest/helpers/azion.config.example.js
+++ b/lib/utils/generateManifest/helpers/azion.config.example.js
@@ -14,10 +14,37 @@ export default {
   },
   origin: [
     {
-      name: 'myneworigin',
-      type: 'object_storage',
-      bucket: 'blue-courage',
-      prefix: '0101010101001',
+      id: 123, // Optional. ID of your origin. Obtain this value via GET request. Cannot be changed via API.
+      key: 'myorigin', // Optional. Key of your origin. Obtain this value via GET request. Cannot be changed via API.
+      name: 'myneworigin', // Required
+      type: 'single_origin', // Required. single_origin, load_balancer, object_storage, live_ingest. Defaults to single_origin if not provided
+      path: '/', // Optional. Default '/' if not provided
+      addresses: [
+        // Required for single_origin, load_balancer, live_ingest. Optional for object_storage
+        // or addresses: ['http.bin.org']
+        {
+          address: 'http.bin.org',
+          weight: 1, // Optional. Assign a number from 1 to 10 to determine how much traffic a server can handle.
+        },
+      ],
+      protocolPolicy: 'preserve', // Optional. preserve, https, http. Defaults to preserve if not provided
+      hostHeader: '${host}', // Defaults to '${host}' if not provided
+      connectionTimeout: 60, // Optional. Default 60 if not provided
+      timeoutBetweenBytes: 120, // Optional. Default 120 if not provided
+      isOriginRedirectionEnabled: false, // Optional. Default false if not provided
+      hmac: {
+        regionName: 'us-east-1', // Required for hmac
+        accessKey: 'myaccesskey', // Required for hmac
+        secretKey: 'secretKey', // Required for hmac
+      }, // Optional
+    },
+    {
+      id: 456, // Optional. ID of your origin. Obtain this value via GET request. Cannot be changed via API.
+      key: 'myorigin', // Optional. Key of your origin. Obtain this value via GET request. Cannot be changed via API.
+      name: 'myneworigin', // Required
+      type: 'object_storage', // Required. single_origin, load_balancer, object_storage, live_ingest. Defaults to single_origin if not provided
+      bucket: 'blue-courage', // Required for object_storage
+      prefix: '0101010101001', // Optional. Default '' if not provided
     },
   ],
   cache: [

--- a/lib/utils/generateManifest/helpers/azion.config.example.js
+++ b/lib/utils/generateManifest/helpers/azion.config.example.js
@@ -31,7 +31,7 @@ export default {
       hostHeader: '${host}', // Defaults to '${host}' if not provided
       connectionTimeout: 60, // Optional. Default 60 if not provided
       timeoutBetweenBytes: 120, // Optional. Default 120 if not provided
-      redirectionEnabled: false, // Optional. Default false if not provided
+      redirection: false, // Optional. Default false if not provided
       hmac: {
         region: 'us-east-1', // Required for hmac
         accessKey: 'myaccesskey', // Required for hmac

--- a/lib/utils/generateManifest/helpers/schema.js
+++ b/lib/utils/generateManifest/helpers/schema.js
@@ -6,13 +6,28 @@ const azionConfigSchema = {
       items: {
         type: 'object',
         properties: {
+          id: {
+            type: 'integer',
+            errorMessage: "The 'id' field must be a number.",
+          },
+          key: {
+            type: 'string',
+            errorMessage: "The 'key' field must be a string.",
+          },
           name: {
             type: 'string',
             errorMessage: "The 'name' field must be a string.",
           },
           type: {
             type: 'string',
-            errorMessage: "The 'type' field must be a string.",
+            enum: [
+              'single_origin',
+              'object_storage',
+              'load_balancer',
+              'live_ingest',
+            ],
+            errorMessage:
+              "The 'type' field must be a string and one of 'single_origin', 'object_storage', 'load_balancer' or 'live_ingest'.",
           },
           bucket: {
             type: ['string', 'null'],
@@ -23,15 +38,101 @@ const azionConfigSchema = {
             errorMessage: "The 'prefix' field must be a string or null.",
           },
           addresses: {
-            type: 'array',
-            items: {
-              type: 'string',
-              errorMessage: "The 'address' field must be a string.",
-            },
+            anyOf: [
+              {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+                errorMessage: {
+                  type: "The 'addresses' field must be an array of strings.",
+                },
+              },
+              {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    address: {
+                      type: 'string',
+                      errorMessage: "The 'address' field must be a string.",
+                    },
+                    weight: {
+                      type: 'integer',
+                    },
+                  },
+                  required: ['address'],
+                  additionalProperties: false,
+                  errorMessage: {
+                    type: "The 'addresses' field must be an array of objects.",
+                    additionalProperties:
+                      'No additional properties are allowed in address items.',
+                    required:
+                      "The 'address' field is required in each address item.",
+                  },
+                },
+              },
+            ],
           },
           hostHeader: {
             type: 'string',
             errorMessage: "The 'hostHeader' field must be a string.",
+          },
+          protocolPolicy: {
+            type: 'string',
+            enum: ['preserve', 'http', 'https'],
+            errorMessage:
+              "The 'protocolPolicy' field must be either 'http', 'https' or 'preserve'. Default is 'preserve'.",
+          },
+          isOriginRedirectionEnabled: {
+            type: 'boolean',
+            errorMessage:
+              "The 'isOriginRedirectionEnabled' field must be a boolean.",
+          },
+          method: {
+            type: 'string',
+            enum: ['ip_hash', 'least_connections', 'round_robin'],
+            errorMessage:
+              "The 'method' field must be either 'ip_hash', 'least_connections' or 'round_robin'. Default is 'ip_hash'.",
+          },
+          path: {
+            type: 'string',
+            errorMessage: "The 'path' field must be a string.",
+          },
+          connectionTimeout: {
+            type: 'integer',
+            errorMessage:
+              "The 'connectionTimeout' field must be a number. Default is 60.",
+          },
+          timeoutBetweenBytes: {
+            type: 'integer',
+            errorMessage:
+              "The 'timeoutBetweenBytes' field must be a number. Default is 120.",
+          },
+          hmac: {
+            type: 'object',
+            properties: {
+              regionName: {
+                type: 'string',
+                errorMessage: "The 'regionName' field must be a string.",
+              },
+              accessKey: {
+                type: 'string',
+                errorMessage: "The 'accessKey' field must be a string.",
+              },
+              secretKey: {
+                type: 'string',
+                errorMessage: "The 'secretKey' field must be a string.",
+              },
+            },
+            required: ['regionName', 'accessKey', 'secretKey'],
+            additionalProperties: false,
+            errorMessage: {
+              additionalProperties:
+                'No additional properties are allowed in the hmac object.',
+              required:
+                "The 'regionName, accessKey and secretKey' fields are required in the hmac object.",
+            },
           },
         },
         required: ['name', 'type'],

--- a/lib/utils/generateManifest/helpers/schema.js
+++ b/lib/utils/generateManifest/helpers/schema.js
@@ -84,9 +84,9 @@ const azionConfigSchema = {
             errorMessage:
               "The 'protocolPolicy' field must be either 'http', 'https' or 'preserve'. Default is 'preserve'.",
           },
-          redirectionEnabled: {
+          redirection: {
             type: 'boolean',
-            errorMessage: "The 'redirectionEnabled' field must be a boolean.",
+            errorMessage: "The 'redirection' field must be a boolean.",
           },
           method: {
             type: 'string',

--- a/lib/utils/generateManifest/helpers/schema.js
+++ b/lib/utils/generateManifest/helpers/schema.js
@@ -84,10 +84,9 @@ const azionConfigSchema = {
             errorMessage:
               "The 'protocolPolicy' field must be either 'http', 'https' or 'preserve'. Default is 'preserve'.",
           },
-          isOriginRedirectionEnabled: {
+          redirectionEnabled: {
             type: 'boolean',
-            errorMessage:
-              "The 'isOriginRedirectionEnabled' field must be a boolean.",
+            errorMessage: "The 'redirectionEnabled' field must be a boolean.",
           },
           method: {
             type: 'string',
@@ -112,9 +111,9 @@ const azionConfigSchema = {
           hmac: {
             type: 'object',
             properties: {
-              regionName: {
+              region: {
                 type: 'string',
-                errorMessage: "The 'regionName' field must be a string.",
+                errorMessage: "The 'region' field must be a string.",
               },
               accessKey: {
                 type: 'string',
@@ -125,13 +124,13 @@ const azionConfigSchema = {
                 errorMessage: "The 'secretKey' field must be a string.",
               },
             },
-            required: ['regionName', 'accessKey', 'secretKey'],
+            required: ['region', 'accessKey', 'secretKey'],
             additionalProperties: false,
             errorMessage: {
               additionalProperties:
                 'No additional properties are allowed in the hmac object.',
               required:
-                "The 'regionName, accessKey and secretKey' fields are required in the hmac object.",
+                "The 'region, accessKey and secretKey' fields are required in the hmac object.",
             },
           },
         },

--- a/lib/utils/generateManifest/strategy/implementations/originManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/originManifestStrategy.js
@@ -44,7 +44,7 @@ class OriginManifestStrategy extends ManifestStrategy {
           origin.protocolPolicy || 'preserve';
         originSetting.method = origin.method || 'ip_hash';
         originSetting.is_origin_redirection_enabled =
-          origin.redirectionEnabled || false;
+          origin.redirection || false;
         originSetting.connection_timeout = origin.connectionTimeout || 60;
         originSetting.timeout_between_bytes = origin.timeoutBetweenBytes || 120;
 

--- a/lib/utils/generateManifest/strategy/implementations/originManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/originManifestStrategy.js
@@ -39,7 +39,7 @@ class OriginManifestStrategy extends ManifestStrategy {
       };
 
       if (origin.type !== 'object_storage') {
-        originSetting.originPath = origin.originPath || '/';
+        originSetting.origin_path = origin.originPath || '/';
         originSetting.origin_protocol_policy =
           origin.protocolPolicy || 'preserve';
         originSetting.method = origin.method || 'ip_hash';

--- a/lib/utils/generateManifest/strategy/implementations/originManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/originManifestStrategy.js
@@ -19,27 +19,70 @@ class OriginManifestStrategy extends ManifestStrategy {
     if (!Array.isArray(config?.origin) || config?.origin.length === 0) {
       return payload;
     }
+    const originsType = [
+      'single_origin',
+      'object_storage',
+      'load_balancer',
+      'live_ingest',
+    ];
     config?.origin.forEach((origin) => {
-      if (origin.type !== 'object_storage' && origin.type !== 'single_origin') {
+      if (originsType.indexOf(origin.type) === -1) {
         throw new Error(
           `Rule setOrigin originType '${origin.type}' is not supported`,
         );
       }
       const originSetting = {
+        id: origin.id,
+        key: origin.key,
         name: origin.name,
         origin_type: origin.type,
       };
 
-      if (origin.type === 'object_storage') {
+      if (origin.type !== 'object_storage') {
+        originSetting.originPath = origin.originPath || '/';
+        originSetting.origin_protocol_policy =
+          origin.protocolPolicy || 'preserve';
+        originSetting.method = origin.method || 'ip_hash';
+        originSetting.is_origin_redirection_enabled =
+          origin.isOriginRedirectionEnabled || false;
+        originSetting.connection_timeout = origin.connectionTimeout || 60;
+        originSetting.timeout_between_bytes = origin.timeoutBetweenBytes || 120;
+
+        if (origin.addresses && origin.addresses.length > 0) {
+          const addresses = [];
+          origin?.addresses.forEach((address) => {
+            if (typeof address === 'string') {
+              addresses.push({
+                address,
+              });
+              return;
+            }
+            if (address?.weight < 0 || address?.weight > 10) {
+              throw new Error(
+                `When origin type is ${origin.type}, weight must be between 0 and 10`,
+              );
+            }
+            addresses.push(address);
+          });
+          originSetting.addresses = addresses;
+        } else {
+          throw new Error(
+            `When origin type is ${origin.type}, addresses is required`,
+          );
+        }
+
+        originSetting.host_header = origin.hostHeader || '${host}';
+        if (origin?.hmac) {
+          originSetting.hmac_authentication = true;
+          originSetting.hmac_region_name = origin.hmac?.regionName;
+          originSetting.hmac_access_key = origin.hmac?.accessKey;
+          originSetting.hmac_secret_key = origin.hmac?.secretKey;
+        }
+      } else if (origin.type === 'object_storage') {
         originSetting.bucket = origin.bucket;
-        originSetting.prefix = origin.prefix;
+        originSetting.prefix = origin.prefix || '';
       }
-      if (origin.type === 'single_origin') {
-        originSetting.addresses = origin.addresses?.map((address) => {
-          return { address };
-        });
-        originSetting.host_header = origin.hostHeader;
-      }
+
       payload.push(originSetting);
     });
     return payload;

--- a/lib/utils/generateManifest/strategy/implementations/originManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/originManifestStrategy.js
@@ -44,7 +44,7 @@ class OriginManifestStrategy extends ManifestStrategy {
           origin.protocolPolicy || 'preserve';
         originSetting.method = origin.method || 'ip_hash';
         originSetting.is_origin_redirection_enabled =
-          origin.isOriginRedirectionEnabled || false;
+          origin.redirectionEnabled || false;
         originSetting.connection_timeout = origin.connectionTimeout || 60;
         originSetting.timeout_between_bytes = origin.timeoutBetweenBytes || 120;
 
@@ -74,7 +74,7 @@ class OriginManifestStrategy extends ManifestStrategy {
         originSetting.host_header = origin.hostHeader || '${host}';
         if (origin?.hmac) {
           originSetting.hmac_authentication = true;
-          originSetting.hmac_region_name = origin.hmac?.regionName;
+          originSetting.hmac_region_name = origin.hmac?.region;
           originSetting.hmac_access_key = origin.hmac?.accessKey;
           originSetting.hmac_secret_key = origin.hmac?.secretKey;
         }


### PR DESCRIPTION
### Feat added all origins parameters to the manifest

Added parameters for origins in manifest generation based on API v3.

Example:

```js
module.exports = {
   origin: [
      {
         name: 'myneworigin', // Required
         type: 'object_storage', // Required. single_origin, load_balancer, object_storage, live_ingest.
         bucket: 'blue-courage', // Required for object_storage
         prefix: '0101010101001', // Optional. Default '' if not provided
      },
   ]
}

```

For the full example, see: `./lib/utils/generateManifest/helpers/azion.config.example.js`

### Tests:

```bash
yarn jest lib/utils/generateManifest/generateManifest.utils.test.js
```
