### PR TITLE
feat: added purge parameters to the manifest

### DIFF
--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -10,6 +10,7 @@ import OriginManifestStrategy from './strategy/implementations/originManifestStr
 import CacheManifestStrategy from './strategy/implementations/cacheManifestStrategy.js';
 import RulesManifestStrategy from './strategy/implementations/rulesManifestStrategy.js';
 import DomainManisfestStrategy from './strategy/implementations/domainManifestStrategy.js';
+import PurgeManifestStrategy from './strategy/implementations/purgeManifestStrategy.js';
 
 /**
  * Validates the provided configuration against a JSON Schema.
@@ -49,6 +50,7 @@ function jsToJson(inputConfig) {
   manifestContext.setStrategy('origin', new OriginManifestStrategy());
   manifestContext.setStrategy('cache', new CacheManifestStrategy());
   manifestContext.setStrategy('domain', new DomainManisfestStrategy());
+  manifestContext.setStrategy('purge', new PurgeManifestStrategy());
 
   // Rules must be last to apply to behaviors (origin, cache...)
   manifestContext.setStrategy('rules', new RulesManifestStrategy());

--- a/lib/utils/generateManifest/generateManifest.utils.js
+++ b/lib/utils/generateManifest/generateManifest.utils.js
@@ -20,7 +20,7 @@ import PurgeManifestStrategy from './strategy/implementations/purgeManifestStrat
  * @throws {Error} Throws an error if the configuration fails validation.
  */
 function validateConfig(config) {
-  const ajv = new Ajv({ allErrors: true, $data: true });
+  const ajv = new Ajv({ allErrors: true, $data: true, allowUnionTypes: true });
   ajvErrors(ajv);
   addKeywords(ajv, ['instanceof']);
   const validate = ajv.compile(azionConfigSchema);

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -1754,7 +1754,24 @@ describe('Utils - generateManifest', () => {
       };
 
       expect(() => jsToJson(azionConfig)).toThrow(
-        'Domain mydomain has an invalid digital certificate ID: mycert',
+        "Domain mydomain has an invalid digital certificate ID: mycert. Only 'lets_encrypt' or null is supported.",
+      );
+    });
+
+    it('should correctly process the manifest config when the domain digitalCertificateId is null', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          digitalCertificateId: null,
+        },
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          digital_certificate_id: null,
+        }),
       );
     });
 
@@ -1771,6 +1788,22 @@ describe('Utils - generateManifest', () => {
         expect.objectContaining({
           name: 'mydomain',
           digital_certificate_id: 'lets_encrypt',
+        }),
+      );
+    });
+
+    it('should correctly process the manifest config when the domain digitalCertificateId is number', () => {
+      const azionConfig = {
+        domain: {
+          name: 'mydomain',
+          digitalCertificateId: 12345,
+        },
+      };
+      const result = jsToJson(azionConfig);
+      expect(result.domain).toEqual(
+        expect.objectContaining({
+          name: 'mydomain',
+          digital_certificate_id: 12345,
         }),
       );
     });

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -2070,15 +2070,15 @@ describe('Utils - generateManifest', () => {
       };
 
       expect(() => jsToJson(azionConfig)).toThrow(
-        "The 'type' field must be either 'url', 'cachekeys' or 'wildcard'.",
+        "The 'type' field must be either 'url', 'cachekey' or 'wildcard'.",
       );
     });
 
-    it('should correctly process the manifest config when the purge is type cachekeys', () => {
+    it('should correctly process the manifest config when the purge is type cachekey', () => {
       const azionConfig = {
         purge: [
           {
-            type: 'cachekeys',
+            type: 'cachekey',
             urls: ['https://example.com/test1', 'https://example.com/test2'],
           },
         ],
@@ -2088,7 +2088,7 @@ describe('Utils - generateManifest', () => {
       expect(result.purge).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            type: 'cachekeys',
+            type: 'cachekey',
             urls: ['https://example.com/test1', 'https://example.com/test2'],
             method: 'delete',
           }),
@@ -2096,11 +2096,11 @@ describe('Utils - generateManifest', () => {
       );
     });
 
-    it('should correctly process the manifest config when the purge is type cachekeys and layer is provided', () => {
+    it('should correctly process the manifest config when the purge is type cachekey and layer is provided', () => {
       const azionConfig = {
         purge: [
           {
-            type: 'cachekeys',
+            type: 'cachekey',
             urls: ['https://example.com/test1', 'https://example.com/test2'],
             layer: 'edge_caching',
           },
@@ -2111,7 +2111,7 @@ describe('Utils - generateManifest', () => {
       expect(result.purge).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            type: 'cachekeys',
+            type: 'cachekey',
             urls: ['https://example.com/test1', 'https://example.com/test2'],
             method: 'delete',
             layer: 'edge_caching',
@@ -2120,11 +2120,11 @@ describe('Utils - generateManifest', () => {
       );
     });
 
-    it('should throw an error when the purge is type cachekeys and layer is invalid', () => {
+    it('should throw an error when the purge is type cachekey and layer is invalid', () => {
       const azionConfig = {
         purge: [
           {
-            type: 'cachekeys',
+            type: 'cachekey',
             urls: ['https://example.com/test'],
             layer: 'invalid',
           },

--- a/lib/utils/generateManifest/generateManifest.utils.test.js
+++ b/lib/utils/generateManifest/generateManifest.utils.test.js
@@ -1996,4 +1996,181 @@ describe('Utils - generateManifest', () => {
       );
     });
   });
+
+  describe('jsToJson - Purge', () => {
+    it('should correctly process the manifest config when the purge is type url', () => {
+      const azionConfig = {
+        purge: [
+          {
+            type: 'url',
+            urls: ['https://example.com'],
+          },
+        ],
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.purge).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'url',
+            urls: ['https://example.com'],
+            method: 'delete',
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly process the manifest config when the purge is type url and method is provided', () => {
+      const azionConfig = {
+        purge: [
+          {
+            type: 'url',
+            urls: ['https://example.com'],
+            method: 'delete',
+          },
+        ],
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.purge).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'url',
+            urls: ['https://example.com'],
+            method: 'delete',
+          }),
+        ]),
+      );
+    });
+
+    it('should throw an error when the purge is method is invalid', () => {
+      const azionConfig = {
+        purge: [
+          {
+            type: 'url',
+            urls: ['https://example.com'],
+            method: 'invalid',
+          },
+        ],
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'method' field must be either 'delete'. Default is 'delete'.",
+      );
+    });
+
+    it('should throw an error when the purge is type is invalid', () => {
+      const azionConfig = {
+        purge: [
+          {
+            type: 'invalid',
+            urls: ['https://example.com'],
+          },
+        ],
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'type' field must be either 'url', 'cachekeys' or 'wildcard'.",
+      );
+    });
+
+    it('should correctly process the manifest config when the purge is type cachekeys', () => {
+      const azionConfig = {
+        purge: [
+          {
+            type: 'cachekeys',
+            urls: ['https://example.com/test1', 'https://example.com/test2'],
+          },
+        ],
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.purge).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'cachekeys',
+            urls: ['https://example.com/test1', 'https://example.com/test2'],
+            method: 'delete',
+          }),
+        ]),
+      );
+    });
+
+    it('should correctly process the manifest config when the purge is type cachekeys and layer is provided', () => {
+      const azionConfig = {
+        purge: [
+          {
+            type: 'cachekeys',
+            urls: ['https://example.com/test1', 'https://example.com/test2'],
+            layer: 'edge_caching',
+          },
+        ],
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.purge).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'cachekeys',
+            urls: ['https://example.com/test1', 'https://example.com/test2'],
+            method: 'delete',
+            layer: 'edge_caching',
+          }),
+        ]),
+      );
+    });
+
+    it('should throw an error when the purge is type cachekeys and layer is invalid', () => {
+      const azionConfig = {
+        purge: [
+          {
+            type: 'cachekeys',
+            urls: ['https://example.com/test'],
+            layer: 'invalid',
+          },
+        ],
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'layer' field must be either 'edge_caching' or 'l2_caching'. Default is 'edge_caching'.",
+      );
+    });
+
+    it('should correctly process the manifest config when the purge is type wildcard', () => {
+      const azionConfig = {
+        purge: [
+          {
+            type: 'wildcard',
+            urls: ['https://example.com/*'],
+          },
+        ],
+      };
+
+      const result = jsToJson(azionConfig);
+      expect(result.purge).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'wildcard',
+            urls: ['https://example.com/*'],
+            method: 'delete',
+          }),
+        ]),
+      );
+    });
+
+    it('should throw an error when the purge urls is not an array', () => {
+      const azionConfig = {
+        purge: [
+          {
+            type: 'url',
+            urls: 'https://example.com',
+          },
+        ],
+      };
+
+      expect(() => jsToJson(azionConfig)).toThrow(
+        "The 'urls' field must be an array of strings.",
+      );
+    });
+  });
 });

--- a/lib/utils/generateManifest/helpers/azion.config.example.js
+++ b/lib/utils/generateManifest/helpers/azion.config.example.js
@@ -304,4 +304,19 @@ export default {
       },
     ],
   },
+  purge: [
+    {
+      type: 'url',
+      urls: ['http://www.example.com/image.jpg'],
+    },
+    {
+      type: 'cachekeys',
+      urls: ['cache_key_1', 'cache_key_2'],
+      method: 'delete',
+    },
+    {
+      type: 'wildcard',
+      urls: ['http://www.example.com/*'],
+    },
+  ],
 };

--- a/lib/utils/generateManifest/helpers/azion.config.example.js
+++ b/lib/utils/generateManifest/helpers/azion.config.example.js
@@ -310,8 +310,8 @@ export default {
       urls: ['http://www.example.com/image.jpg'],
     },
     {
-      type: 'cachekeys',
-      urls: ['cache_key_1', 'cache_key_2'],
+      type: 'cachekey',
+      urls: ['https://example.com/test1', 'https://example.com/test2'],
       method: 'delete',
     },
     {

--- a/lib/utils/generateManifest/helpers/schema.js
+++ b/lib/utils/generateManifest/helpers/schema.js
@@ -804,6 +804,50 @@ const azionConfigSchema = {
         required: "The 'name' field is required in the domain object.",
       },
     },
+    purge: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['url', 'cachekeys', 'wildcard'],
+            errorMessage:
+              "The 'type' field must be either 'url', 'cachekeys' or 'wildcard'.",
+          },
+          urls: {
+            type: 'array',
+            items: {
+              type: 'string',
+              errorMessage: "Each item in 'urls' must be a string.",
+            },
+            errorMessage: {
+              type: "The 'urls' field must be an array of strings.",
+            },
+          },
+          method: {
+            type: 'string',
+            enum: ['delete'],
+            errorMessage:
+              "The 'method' field must be either 'delete'. Default is 'delete'.",
+          },
+          layer: {
+            type: 'string',
+            enum: ['edge_caching', 'l2_caching'],
+            errorMessage:
+              "The 'layer' field must be either 'edge_caching' or 'l2_caching'. Default is 'edge_caching'.",
+          },
+        },
+        required: ['type', 'urls'],
+        additionalProperties: false,
+        errorMessage: {
+          additionalProperties:
+            'No additional properties are allowed in purge items.',
+          required:
+            "The 'type and urls' fields are required in each purge item.",
+        },
+      },
+    },
   },
   required: [],
   additionalProperties: false,

--- a/lib/utils/generateManifest/helpers/schema.js
+++ b/lib/utils/generateManifest/helpers/schema.js
@@ -811,9 +811,9 @@ const azionConfigSchema = {
         properties: {
           type: {
             type: 'string',
-            enum: ['url', 'cachekeys', 'wildcard'],
+            enum: ['url', 'cachekey', 'wildcard'],
             errorMessage:
-              "The 'type' field must be either 'url', 'cachekeys' or 'wildcard'.",
+              "The 'type' field must be either 'url', 'cachekey' or 'wildcard'.",
           },
           urls: {
             type: 'array',

--- a/lib/utils/generateManifest/helpers/schema.js
+++ b/lib/utils/generateManifest/helpers/schema.js
@@ -767,6 +767,7 @@ const azionConfigSchema = {
           properties: {
             verification: {
               type: 'string',
+              enum: ['enforce', 'permissive'],
               errorMessage: "The 'verification' field must be a string.",
             },
             trustedCaCertificateId: {

--- a/lib/utils/generateManifest/helpers/schema.js
+++ b/lib/utils/generateManifest/helpers/schema.js
@@ -759,8 +759,9 @@ const azionConfigSchema = {
           errorMessage: "The 'edgeFirewallId' field must be a number.",
         },
         digitalCertificateId: {
-          type: 'string',
-          errorMessage: "The 'digitalCertificateId' field must be a string.",
+          type: ['string', 'number', 'null'],
+          errorMessage:
+            "The 'digitalCertificateId' field must be a string, number or null. If string, it must be 'lets_encrypt'.",
         },
         mtls: {
           type: 'object',

--- a/lib/utils/generateManifest/strategy/implementations/domainManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/domainManifestStrategy.js
@@ -21,6 +21,7 @@ class DomainManisfestStrategy extends ManifestStrategy {
     }
     if (
       domain.digitalCertificateId &&
+      typeof domain.digitalCertificateId === 'string' &&
       domain.digitalCertificateId !== 'lets_encrypt'
     ) {
       throw new Error(

--- a/lib/utils/generateManifest/strategy/implementations/purgeManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/purgeManifestStrategy.js
@@ -40,7 +40,7 @@ class PurgeManifestStrategy extends ManifestStrategy {
         method: purge.method || 'delete',
       };
 
-      if (purge?.type === 'cachekeys') {
+      if (purge?.type === 'cachekey') {
         purgeSetting.layer = purge.layer || 'edge_caching';
       }
 

--- a/lib/utils/generateManifest/strategy/implementations/purgeManifestStrategy.js
+++ b/lib/utils/generateManifest/strategy/implementations/purgeManifestStrategy.js
@@ -1,0 +1,53 @@
+import ManifestStrategy from '../manifestStrategy.js';
+
+/**
+ * PurgeManifestStrategy
+ * @class PurgeManifestStrategy
+ * @description This class is implementation of the Purge Manifest Strategy.
+ */
+class PurgeManifestStrategy extends ManifestStrategy {
+  /**
+   * Generates the purge manifest based on the configuration.
+   * @param {object} config - The configuration object.
+   * @param {object} context - The context object.
+   * @returns {object} The generated purge manifest.
+   * @throws {Error} When the purge type is not supported.
+   */
+  // eslint-disable-next-line no-unused-vars, class-methods-use-this
+  generate(config, context) {
+    const payload = [];
+    if (!Array.isArray(config?.purge) || config?.purge.length === 0) {
+      return payload;
+    }
+    config?.purge.forEach((purge) => {
+      purge?.urls.forEach((value) => {
+        if (!value.includes('http://') && !value.includes('https://')) {
+          throw new Error(
+            'The URL must contain the protocol (http:// or https://).',
+          );
+        }
+
+        if (purge?.type === 'wildcard' && !value.includes('*')) {
+          throw new Error(
+            'The URL must not contain the wildcard character (*).',
+          );
+        }
+      });
+
+      const purgeSetting = {
+        type: purge.type,
+        urls: purge.urls || [],
+        method: purge.method || 'delete',
+      };
+
+      if (purge?.type === 'cachekeys') {
+        purgeSetting.layer = purge.layer || 'edge_caching';
+      }
+
+      payload.push(purgeSetting);
+    });
+    return payload;
+  }
+}
+
+export default PurgeManifestStrategy;


### PR DESCRIPTION
### Feat added purge parameters to the manifest

Added parameters for purge in manifest generation based on API v3.

Example:

```js
module.exports = {
   purge: [
    {
      type: 'url',
      urls: ['http://www.example.com/image.jpg'],
    },
    {
      type: 'cachekey',
      urls: ['http://www.example.com/image1.png', 'http://www.example.com/image2.png'],
      method: 'delete',
    },
    {
      type: 'wildcard',
      urls: ['http://www.example.com/*'],
    },
  ],
}

```

For the full example, see: `./lib/utils/generateManifest/helpers/azion.config.example.js`

### Tests:

```bash
yarn jest lib/utils/generateManifest/generateManifest.utils.test.js -t "jsToJson - Purge"
```

### Bonus:

fix: update digitalCertificateId field configuration to accept number type

It was updated in the Ajv schema to authorize multiple types.
And added the number type in the digitalCertificateId field of the Domain.
